### PR TITLE
7 sending takes too long

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -16,5 +16,9 @@ pub enum NetworkError {
     #[fail(display = "TCP client connections hash was poisoned")]
     TcpClientConnectionsHashPoisoned,
     #[fail(display = "The lock for a specific TCP client was poisoned")]
-    TcpClientLockFailed
+    TcpClientLockFailed,
+    #[fail(display = "Unable to create UDP SocketState structure")]
+    UDPSocketStateCreationFailed,
+    #[fail(display = "Unable to set nonblocking option")]
+    UnableToSetNonblocking
 }

--- a/src/net/socket_state.rs
+++ b/src/net/socket_state.rs
@@ -2,7 +2,7 @@ use bincode::serialize;
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use super::{Connection, Packet, RawPacket, SocketAddr};
 use error::{NetworkError, Result};
@@ -12,7 +12,7 @@ use error::{NetworkError, Result};
 type ConnectionTimeout = u64;
 type ConnectionMap = Arc<RwLock<HashMap<SocketAddr, Arc<RwLock<Connection>>>>>;
 
-// Default timeout of 10 seconds
+// Default timeout of a specific client
 const TIMEOUT_DEFAULT: ConnectionTimeout = 10;
 
 // Default time between checks of all clients for timeouts in seconds
@@ -22,16 +22,22 @@ const TIMEOUT_POLL_INTERVAL: u64 = 1;
 pub struct SocketState {
     timeout: ConnectionTimeout,
     connections: ConnectionMap,
+    timeout_check_thread: Option<thread::JoinHandle<()>>
 }
 
 impl SocketState {
-    pub fn new() -> SocketState {
+    pub fn new() -> Result<SocketState> {
         let mut socket_state = SocketState {
             connections: Arc::new(RwLock::new(HashMap::new())),
             timeout: TIMEOUT_DEFAULT,
+            timeout_check_thread: None
         };
-        socket_state.check_for_timeouts();
-        socket_state
+        if let Ok(thread_handle) = socket_state.check_for_timeouts() {
+            socket_state.timeout_check_thread = Some(thread_handle);
+            Ok(socket_state)
+        } else {
+            Err(NetworkError::UDPSocketStateCreationFailed.into())
+        }
     }
 
     pub fn with_client_timeout(mut self, timeout: ConnectionTimeout) -> SocketState {
@@ -94,28 +100,40 @@ impl SocketState {
         })
     }
 
-    // Regularly checks the last_heard attribute of all the connections in the manager to see if any have timed out
-    fn check_for_timeouts(&mut self) {
+    // This function starts a background thread that does the following:
+    // 1. Gets a read lock on the HashMap containing all the connections
+    // 2. Iterate through each one
+    // 3. Check if the last time we have heard from them (received a packet from them) is greater than the amount of time considered to be a timeout
+    // 4. If they have timed out, send a notification up the stack
+    fn check_for_timeouts(&mut self) -> Result<thread::JoinHandle<()>> {
         let connections_lock = self.connections.clone();
         let sleepy_time = Duration::from_secs(self.timeout);
         let poll_interval = Duration::from_secs(TIMEOUT_POLL_INTERVAL);
 
-        thread::Builder::new()
+        Ok(thread::Builder::new()
             .name("check_for_timeouts".into())
             .spawn(move || loop {
-                let connections = connections_lock.read().expect("Unable to aquire read lock");
-
-                for (key, value) in connections.iter() {
-                    let connection = value.read().expect("Unable to aquire read lock");
-                    let last_heard = connection.last_heard();
-                    if last_heard >= sleepy_time {
-                        // TODO: pass up client TimedOut event
-                        error!("Client has timed out: {:?}", key);
+                {
+                    debug!("Checking for timeouts");
+                    match connections_lock.read() {
+                        Ok(lock) => {
+                            for (key, value) in lock.iter() {
+                                if let Ok(c) = value.read() {
+                                    if c.last_heard() >= sleepy_time {
+                                        // TODO: pass up client TimedOut event
+                                        error!("Client has timed out: {:?}", key);
+                                    }
+                                }
+                            }
+                        },
+                        Err(e) => {
+                            error!("Unable to acquire read lock to check for timed out connections")
+                        }
                     }
                 }
-
-                thread::sleep(poll_interval)
-            }).unwrap();
+                thread::sleep(poll_interval);
+            })?
+        )
     }
 
     #[inline]
@@ -164,7 +182,6 @@ mod test {
     #[test]
     fn test_poll_for_invalid_clients() {
         let mut socket_state = SocketState::new();
-        socket_state.check_for_timeouts();
-        thread::sleep(time::Duration::from_millis(10000));
+        thread::sleep(time::Duration::from_secs(10));
     }
 }

--- a/src/net/socket_state.rs
+++ b/src/net/socket_state.rs
@@ -108,8 +108,8 @@ impl SocketState {
         Ok(thread::Builder::new()
             .name("check_for_timeouts".into())
             .spawn(move || loop {
-                {
-                    debug!("Checking for timeouts");
+                
+                    trace!("Checking for timeouts");
                     match connections.read() {
                         Ok(lock) => {
                             for (key, value) in lock.iter() {
@@ -125,7 +125,7 @@ impl SocketState {
                             error!("Unable to acquire read lock to check for timed out connections")
                         }
                     }
-                }
+
                 thread::sleep(poll_interval);
             })?
         )


### PR DESCRIPTION
This fixes the background timeout check thread from holding on to the read lock while it sleeps. It also adds comments to the public functions, and normalizes the errors to use our error module.