### PR TITLE
Fixed various suggestions proposed by clippy.

### DIFF
--- a/src/net/connection.rs
+++ b/src/net/connection.rs
@@ -22,8 +22,8 @@ impl Connection {
         Connection {
             seq_num: 0,
             dropped_packets: Vec::new(),
-            waiting_packets: LocalAckRecord::new(),
-            their_acks: ExternalAcks::new(),
+            waiting_packets: Default::default(),
+            their_acks: Default::default(),
             last_heard: Instant::now(),
             quality: Quality::Good,
             remote_address: addr,

--- a/src/net/external_ack.rs
+++ b/src/net/external_ack.rs
@@ -4,7 +4,7 @@
 ///
 /// Here we store information about the other side (virtual connection).
 /// Like witch is the last sequence number from them.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct ExternalAcks {
     /// the last sequence number we have received from the other side.
     pub last_seq: u16,
@@ -13,14 +13,6 @@ pub struct ExternalAcks {
 }
 
 impl ExternalAcks {
-    pub fn new() -> ExternalAcks {
-        ExternalAcks {
-            last_seq: 0,
-            field: 0,
-            initialized: false,
-        }
-    }
-
     pub fn ack(&mut self, seq_num: u16) {
         if !self.initialized {
             self.last_seq = seq_num;
@@ -43,7 +35,7 @@ impl ExternalAcks {
             }
             self.last_seq = seq_num;
         } else if neg_diff <= 32 {
-            self.field = self.field | (1 << neg_diff - 1);
+            self.field |= 1 << neg_diff - 1;
         }
     }
 }
@@ -54,7 +46,7 @@ mod test {
 
     #[test]
     fn acking_single_packet() {
-        let mut acks = ExternalAcks::new();
+        let mut acks:ExternalAcks = Default::default();
         acks.ack(0);
 
         assert_eq!(acks.last_seq, 0);
@@ -63,7 +55,7 @@ mod test {
 
     #[test]
     fn acking_several_packets() {
-        let mut acks = ExternalAcks::new();
+        let mut acks:ExternalAcks = Default::default();
         acks.ack(0);
         acks.ack(1);
         acks.ack(2);
@@ -74,7 +66,7 @@ mod test {
 
     #[test]
     fn acking_several_packets_out_of_order() {
-        let mut acks = ExternalAcks::new();
+        let mut acks:ExternalAcks = Default::default();
         acks.ack(1);
         acks.ack(0);
         acks.ack(2);
@@ -85,7 +77,7 @@ mod test {
 
     #[test]
     fn acking_a_nearly_full_set_of_packets() {
-        let mut acks = ExternalAcks::new();
+        let mut acks:ExternalAcks = Default::default();
 
         for i in 0..32 {
             acks.ack(i);
@@ -97,7 +89,7 @@ mod test {
 
     #[test]
     fn acking_a_full_set_of_packets() {
-        let mut acks = ExternalAcks::new();
+        let mut acks:ExternalAcks = Default::default();
 
         for i in 0..33 {
             acks.ack(i);
@@ -109,7 +101,7 @@ mod test {
 
     #[test]
     fn acking_to_the_edge_forward() {
-        let mut acks = ExternalAcks::new();
+        let mut acks:ExternalAcks = Default::default();
         acks.ack(0);
         acks.ack(32);
 
@@ -119,7 +111,7 @@ mod test {
 
     #[test]
     fn acking_too_far_forward() {
-        let mut acks = ExternalAcks::new();
+        let mut acks:ExternalAcks = Default::default();
         acks.ack(0);
         acks.ack(1);
         acks.ack(34);
@@ -130,7 +122,7 @@ mod test {
 
     #[test]
     fn acking_a_whole_buffer_too_far_forward() {
-        let mut acks = ExternalAcks::new();
+        let mut acks:ExternalAcks = Default::default();
         acks.ack(0);
         acks.ack(60);
 
@@ -140,7 +132,7 @@ mod test {
 
     #[test]
     fn acking_too_far_backward() {
-        let mut acks = ExternalAcks::new();
+        let mut acks:ExternalAcks = Default::default();
         acks.ack(33);
         acks.ack(0);
 
@@ -150,7 +142,7 @@ mod test {
 
     #[test]
     fn acking_around_zero() {
-        let mut acks = ExternalAcks::new();
+        let mut acks:ExternalAcks = Default::default();
 
         for i in 0..33_u16 {
             acks.ack(i.wrapping_sub(16));
@@ -161,7 +153,7 @@ mod test {
 
     #[test]
     fn ignores_old_packets() {
-        let mut acks = ExternalAcks::new();
+        let mut acks:ExternalAcks = Default::default();
         acks.ack(40);
         acks.ack(0);
         assert_eq!(acks.last_seq, 40);
@@ -170,7 +162,7 @@ mod test {
 
     #[test]
     fn ignores_really_old_packets() {
-        let mut acks = ExternalAcks::new();
+        let mut acks:ExternalAcks = Default::default();
         acks.ack(30000);
         acks.ack(0);
         assert_eq!(acks.last_seq, 30000);
@@ -179,7 +171,7 @@ mod test {
 
     #[test]
     fn skips_missing_acks_correctly() {
-        let mut acks = ExternalAcks::new();
+        let mut acks:ExternalAcks = Default::default();
         acks.ack(0);
         acks.ack(1);
         acks.ack(6);

--- a/src/net/local_ack.rs
+++ b/src/net/local_ack.rs
@@ -6,19 +6,13 @@ use packet::Packet;
 /// Holds up to 32 packets waiting for ack
 ///
 /// Additionally, holds packets "forward" of the current ack packet
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct LocalAckRecord {
     // packets waiting for acknowledgement.
     packets: HashMap<u16, Packet>,
 }
 
 impl LocalAckRecord {
-    pub fn new() -> LocalAckRecord {
-        LocalAckRecord {
-            packets: HashMap::new(),
-        }
-    }
-
     /// Checks if there are packets in the queue to be aknowleged.
     pub fn is_empty(&mut self) -> bool {
         self.packets.is_empty()
@@ -76,7 +70,7 @@ mod test {
 
     #[test]
     fn acking_single_packet() {
-        let mut record = LocalAckRecord::new();
+        let mut record:LocalAckRecord = Default::default();
         record.enqueue(0, dummy_packet());
         let dropped = record.ack(0, 0);
         assert_eq!(dropped.len(), 0);
@@ -85,7 +79,7 @@ mod test {
 
     #[test]
     fn acking_several_packets() {
-        let mut record = LocalAckRecord::new();
+        let mut record:LocalAckRecord = Default::default();
         record.enqueue(0, dummy_packet());
         record.enqueue(1, dummy_packet());
         record.enqueue(2, dummy_packet());
@@ -96,7 +90,7 @@ mod test {
 
     #[test]
     fn acking_a_full_set_of_packets() {
-        let mut record = LocalAckRecord::new();
+        let mut record:LocalAckRecord = Default::default();
 
         for i in 0..33 {
             record.enqueue(i, dummy_packet())
@@ -110,7 +104,7 @@ mod test {
 
     #[test]
     fn dropping_one_packet() {
-        let mut record = LocalAckRecord::new();
+        let mut record:LocalAckRecord = Default::default();
 
         for i in 0..33 {
             record.enqueue(i, dummy_packet());
@@ -124,7 +118,7 @@ mod test {
 
     #[test]
     fn acking_around_zero() {
-        let mut record = LocalAckRecord::new();
+        let mut record:LocalAckRecord = Default::default();
 
         for i in 0..33_u16 {
             record.enqueue(i.wrapping_sub(16), dummy_packet());
@@ -138,7 +132,7 @@ mod test {
 
     #[test]
     fn not_dropping_new_packets() {
-        let mut record = LocalAckRecord::new();
+        let mut record:LocalAckRecord = Default::default();
         record.enqueue(0, dummy_packet());
         record.enqueue(1, dummy_packet());
         record.enqueue(2, dummy_packet());
@@ -151,7 +145,7 @@ mod test {
 
     #[test]
     fn drops_old_packets() {
-        let mut record = LocalAckRecord::new();
+        let mut record:LocalAckRecord = Default::default();
         record.enqueue(0, dummy_packet());
         record.enqueue(40, dummy_packet());
         let dropped = record.ack(40, 0);
@@ -161,7 +155,7 @@ mod test {
 
     #[test]
     fn drops_really_old_packets() {
-        let mut record = LocalAckRecord::new();
+        let mut record:LocalAckRecord = Default::default();
         record.enqueue(50000, dummy_packet());
         record.enqueue(0, dummy_packet());
         record.enqueue(1, dummy_packet());

--- a/src/net/socket_state.rs
+++ b/src/net/socket_state.rs
@@ -171,7 +171,7 @@ impl SocketState {
                                 }
                             }
                         },
-                        Err(e) => {
+                        Err(_e) => {
                             error!("Unable to acquire read lock to check for timed out connections")
                         }
                     }

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -99,7 +99,7 @@ impl TcpServer {
             }
         } else {
             tmp_stream.shutdown(Shutdown::Both);
-            return Err(Error::from(NetworkError::TcpClientConnectionsHashPoisoned));
+            Err(Error::from(NetworkError::TcpClientConnectionsHashPoisoned))
         }
     }
 }
@@ -188,7 +188,7 @@ impl TcpClient {
     fn outgoing_loop(&mut self) -> Result<JoinHandle<()>> {
         let mut writer = match self.raw_stream.try_clone() {
             Ok(w) => { w },
-            Err(e) => {
+            Err(_e) => {
                 return Err(Error::from(NetworkError::TcpStreamCloneFailed));
             }
         };

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -64,7 +64,7 @@ impl UdpSocket {
             Ok(_) => {
                 Ok(())
             }
-            Err(e) => {
+            Err(_e) => {
                 Err(NetworkError::UnableToSetNonblocking.into())
             }
         }


### PR DESCRIPTION
Hello,
I am a young software developer trying to at least take a look at some projects written in Rust to see how they are formed and maybe to contribute as part of Hacktober 2018. I came across your project searching github, and noticed a few errors marked by clippy. This request merges some of the low-hanging fruit detected by clippy. I hope it's useful.

Kind regards,
Krish


-Make use of the Default::default trait for external_ack and local_ack.
-Removed some unused imports
-Changed to use _e for Err match as suggested by clippy (seems to be convention if unused)
-Removed redundant return statement
-Shortened syntax of arithmetic operation and removed brackets (no change in functionality)

Tests still work