### PR TITLE
Change to_socket_addrs to parse, fix some warnings

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -27,9 +27,8 @@ mod test {
 
     #[test]
     fn test_create_event() {
-        let addr = format!("{}:{}", TEST_HOST_IP, TEST_PORT).to_socket_addrs();
-        let mut addr = addr.unwrap();
-        let test_conn = Arc::new(Connection::new(addr.next().unwrap()));
+        let addr = format!("{}:{}", TEST_HOST_IP, TEST_PORT).parse().unwrap();
+        let test_conn = Arc::new(Connection::new(addr));
         let _ = ConnectionEvent::Connected{conn: test_conn};
     }
 }

--- a/src/net/connection.rs
+++ b/src/net/connection.rs
@@ -70,8 +70,8 @@ mod test {
     #[test]
     fn test_create_connection() {
         let mut addr = format!("{}:{}", TEST_HOST_IP, TEST_PORT)
-            .to_socket_addrs()
+            .parse()
             .unwrap();
-        let _new_conn = Connection::new(addr.next().unwrap());
+        let _new_conn = Connection::new(addr);
     }
 }

--- a/src/net/socket_state.rs
+++ b/src/net/socket_state.rs
@@ -221,15 +221,14 @@ mod test {
 
     #[test]
     fn test_create_connection() {
-        let addr = format!("{}:{}", TEST_HOST_IP, TEST_PORT).to_socket_addrs();
+        let addr = format!("{}:{}", TEST_HOST_IP, TEST_PORT).parse();
         assert!(addr.is_ok());
-        let mut addr = addr.unwrap();
-        let new_conn = Connection::new(addr.next().unwrap());
+        let new_conn = Connection::new(addr.unwrap());
     }
 
     #[test]
     fn test_invalid_addr_fails() {
-        let addr = format!("{}:{}", TEST_BAD_HOST_IP, TEST_PORT).to_socket_addrs();
+        let addr: Result<SocketAddr, _> = format!("{}:{}", TEST_BAD_HOST_IP, TEST_PORT).parse();
         assert!(addr.is_err());
     }
 

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -90,11 +90,11 @@ impl TcpServer {
             if let Ok(mut locked_connections) = connections.lock() {
                 locked_connections.insert(peer_addr, tcp_client.clone());
                 // Pass it off to a function to handle setting up the client-specific background threads
-                TcpClient::run(tcp_client);
+                TcpClient::run(tcp_client)?;
                 Ok(())
             } else {
                 // If we can't get the lock, send a shutdown to the client and they will have to try again
-                tmp_stream.shutdown(Shutdown::Both);
+                tmp_stream.shutdown(Shutdown::Both)?;
                 Ok(())
             }
         } else {
@@ -240,7 +240,7 @@ mod test {
     fn test_lock_poisoning() {
         let addr: SocketAddr = ("127.0.0.1".to_string() + ":"+ "27000").parse().unwrap();
         let mut test_state = TcpSocketState::new();
-        test_state.start(addr);
+        test_state.start(addr).unwrap();
         let test_lock = test_state.connections.clone();
         let _ = thread::spawn(move || {
             let _lock = test_lock.lock().unwrap();


### PR DESCRIPTION
`ToSocketAddrs` gave us an iterator and didn't show the behaviour we wanted, so it was changed to `parse`.