### PR TITLE
Add basic Event handling

### DIFF
--- a/examples/server_client.rs
+++ b/examples/server_client.rs
@@ -6,12 +6,7 @@ extern crate laminar;
 
 use std::io::stdin;
 
-use laminar::{
-    error::Result,
-    NetworkConfig,
-    Packet,
-    UdpSocket,
-};
+use laminar::{error::Result, net::NetworkConfig, net::UdpSocket, packet::Packet};
 
 const SERVER: &str = "localhost:12351";
 

--- a/examples/simple_udp.rs
+++ b/examples/simple_udp.rs
@@ -3,39 +3,38 @@
 //! 2. setting up client to send data.
 //! 3. serialize data to send and deserialize when received.
 
-extern crate laminar;
 extern crate bincode;
+extern crate laminar;
 
-use laminar::net::{UdpSocket, SocketAddr, NetworkConfig};
+#[macro_use]
+extern crate serde_derive;
+extern crate serde;
+
+use laminar::net::{NetworkConfig, SocketAddr, UdpSocket};
 use laminar::packet::Packet;
 
-use bincode::{ serialize, deserialize };
-use std::{time, thread};
+use bincode::{deserialize, serialize};
+use std::{thread, time};
 
 /// The socket address of where the server is located.
 const SERVER_ADDR: &'static str = "127.0.0.1:12345";
 // The client address from where the data is sent.
 const CLIENT_ADDR: &'static str = "127.0.0.1:12346";
 
-fn client_address() -> SocketAddr
-{
+fn client_address() -> SocketAddr {
     CLIENT_ADDR.parse().unwrap()
 }
 
-fn server_address() -> SocketAddr
-{
+fn server_address() -> SocketAddr {
     SERVER_ADDR.parse().unwrap()
 }
 
 /// This will run an simple example with client and server communicating.
-pub fn run_simple_example()
-{
+pub fn main() {
     // set up or `Server` that will receive the messages we send with the `Client`
-    let handle = thread::spawn(|| {
-        loop {
-            let mut server = Server::new();
-            server.receive();
-        }
+    let handle = thread::spawn(|| loop {
+        let mut server = Server::new();
+        server.receive();
     });
 
     thread::sleep(time::Duration::from_millis(100));
@@ -43,36 +42,48 @@ pub fn run_simple_example()
     /*  setup or `Client` and send some test data. */
     let mut client = Client::new();
 
-    client.send(DataType::Coords { latitude: 10.55454, longitude: 10.555, altitude: 1.3});
+    client.send(DataType::Coords {
+        latitude: 10.55454,
+        longitude: 10.555,
+        altitude: 1.3,
+    });
 
-    client.send(DataType::Coords { latitude: 3.344, longitude: 5.4545, altitude: 1.33});
+    client.send(DataType::Coords {
+        latitude: 3.344,
+        longitude: 5.4545,
+        altitude: 1.33,
+    });
 
-    client.send(DataType::Text { string: String::from("Some information") });
+    client.send(DataType::Text {
+        string: String::from("Some information"),
+    });
 
     /// ==== result ====
     // Moving to lat: 10.555, long: 10.55454, alt: 1.3
     // Moving to lat: 5.4545, long: 3.344, alt: 1.33
     // Received text: "Some information"
-
     handle.join();
 }
 
 #[derive(Serialize, Deserialize)]
 enum DataType {
-    Coords { longitude: f32, latitude: f32, altitude: f32 },
-    Text { string: String },
+    Coords {
+        longitude: f32,
+        latitude: f32,
+        altitude: f32,
+    },
+    Text {
+        string: String,
+    },
 }
 
 /// This is an test server we use to receive data from clients.
-struct Server
-{
-    udp_socket: UdpSocket
+struct Server {
+    udp_socket: UdpSocket,
 }
 
-impl Server
-{
-    pub fn new() -> Self
-    {
+impl Server {
+    pub fn new() -> Self {
         // you can change the config but if you want just go for the default.
         let config = NetworkConfig::default();
 
@@ -86,10 +97,9 @@ impl Server
     }
 
     /// Receive and block the current thread.
-    pub fn receive(&mut self)
-    {
+    pub fn receive(&mut self) {
         // Next start receiving.
-        let result= self.udp_socket.recv();
+        let result = self.udp_socket.recv();
 
         match result {
             Ok(Some(packet)) => {
@@ -100,10 +110,10 @@ impl Server
                 let deserialized: DataType = deserialize(&received_data).unwrap();
 
                 self.perform_action(deserialized);
-            },
+            }
             Ok(None) => {
                 println!("This could happen when we have'n received all data from this packet yet");
-            },
+            }
             Err(e) => {
                 println!("Something went wrong when receiving, error: {:?}", e);
             }
@@ -111,12 +121,18 @@ impl Server
     }
 
     /// Perform some processing of the data we have received.
-    fn perform_action(&self, data_type: DataType)
-    {
+    fn perform_action(&self, data_type: DataType) {
         match data_type {
-            DataType::Coords { longitude, latitude, altitude } => {
-                println!("Moving to lat: {}, long: {}, alt: {}", longitude, latitude, altitude);
-            },
+            DataType::Coords {
+                longitude,
+                latitude,
+                altitude,
+            } => {
+                println!(
+                    "Moving to lat: {}, long: {}, alt: {}",
+                    longitude, latitude, altitude
+                );
+            }
             DataType::Text { string } => {
                 println!("Received text: {:?}", string);
             }
@@ -125,15 +141,12 @@ impl Server
 }
 
 /// This is an test client to send data to the server.
-struct Client
-{
-    udp_socket: UdpSocket
+struct Client {
+    udp_socket: UdpSocket,
 }
 
-impl Client
-{
-    pub fn new() -> Self
-    {
+impl Client {
+    pub fn new() -> Self {
         // you can change the config but if you want just go for the default.
         let config = NetworkConfig::default();
 
@@ -146,16 +159,15 @@ impl Client
         Client { udp_socket }
     }
 
-    pub fn send(&mut self, data_type: DataType)
-    {
+    pub fn send(&mut self, data_type: DataType) {
         let serialized = serialize(&data_type);
 
         match serialized {
             Ok(raw_data) => {
-                self.udp_socket.send(Packet::new(server_address(), raw_data));
-            },
-            Err(e) => println!("Some error occurred: {:?}", e)
+                self.udp_socket
+                    .send(Packet::new(server_address(), raw_data));
+            }
+            Err(e) => println!("Some error occurred: {:?}", e),
         }
     }
 }
-

--- a/examples/udp.rs
+++ b/examples/udp.rs
@@ -5,7 +5,7 @@
 
 extern crate laminar;
 
-use laminar::net::{UdpSocket, SocketAddr, NetworkConfig};
+use laminar::net::{NetworkConfig, SocketAddr, UdpSocket};
 use laminar::packet::Packet;
 
 /// The socket address of where the server is located.
@@ -13,19 +13,16 @@ const SERVER_ADDR: &'static str = "127.0.0.1:12345";
 // The client address from where the data is sent.
 const CLIENT_ADDR: &'static str = "127.0.0.1:12346";
 
-fn client_address() -> SocketAddr
-{
+fn client_address() -> SocketAddr {
     CLIENT_ADDR.parse().unwrap()
 }
 
-fn server_address() -> SocketAddr
-{
+fn server_address() -> SocketAddr {
     SERVER_ADDR.parse().unwrap()
 }
 
 /// This is an example of how to send data to an specific address.
-pub fn send_data()
-{
+pub fn send_data() {
     // you can change the config but if you want just go for the default.
     let config = NetworkConfig::default();
 
@@ -39,8 +36,7 @@ pub fn send_data()
 }
 
 /// This is an example of how to receive data over udp on an specific socket address with blocking the current thread.
-pub fn receive_data_with_blocking()
-{
+pub fn receive_data_with_blocking() {
     // you can change the config but if you want just go for the default.
     let config = NetworkConfig::default();
 
@@ -60,11 +56,15 @@ pub fn receive_data_with_blocking()
 
             // you can here deserialize your bytes into the data you have passed it when sending.
 
-            println!("Received packet from: {:?} with length {}", endpoint, received_data.len());
-        },
+            println!(
+                "Received packet from: {:?} with length {}",
+                endpoint,
+                received_data.len()
+            );
+        }
         Ok(None) => {
             println!("This could happen when we have'n received all data from this packet yet");
-        },
+        }
         Err(e) => {
             println!("Something went wrong when receiving, error: {:?}", e);
         }
@@ -72,13 +72,12 @@ pub fn receive_data_with_blocking()
 }
 
 /// This is an example of how to receive data over udp on an specific socket address without blocking the current thread.
-pub fn receive_data_without_blocking()
-{
+pub fn receive_data_without_blocking() {
     // you can change the config but if you want just go for the default.
     let config = NetworkConfig::default();
 
     // setup an udp socket and bind it to the client address.
-    let mut udp_socket: UdpSocket = UdpSocket::bind(client_address(),config).unwrap();
+    let mut udp_socket: UdpSocket = UdpSocket::bind(client_address(), config).unwrap();
 
     // next we could specify if or socket should block the current thread when receiving data or not (default = false)
     udp_socket.set_nonblocking(false);
@@ -94,11 +93,15 @@ pub fn receive_data_without_blocking()
 
             // you can here deserialize your bytes into the data you have passed it when sending.
 
-            println!("Received packet from: {:?} with length {}", endpoint, received_data.len());
-        },
+            println!(
+                "Received packet from: {:?} with length {}",
+                endpoint,
+                received_data.len()
+            );
+        }
         Ok(None) => {
             println!("This could happen when we have'n received all data from this packet yet");
-        },
+        }
         Err(e) => {
             // We get an error if receiving would block the thread.
             println!("Something went wrong when receiving, error: {:?}", e);
@@ -107,8 +110,7 @@ pub fn receive_data_without_blocking()
 }
 
 /// This is an example of how to construct an packet.
-pub fn construct_packet() -> Packet
-{
+pub fn construct_packet() -> Packet {
     // this is the destination address of the packet.
     let destination: SocketAddr = server_address();
 
@@ -120,3 +122,6 @@ pub fn construct_packet() -> Packet
 
     packet
 }
+
+// TODO: Use functions in example
+fn main() {}

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,26 +1,30 @@
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 use net::{Connection, Quality};
 
 /// Events that are generated in response to a change in state of the connected client
-pub enum ConnectionEvent {
+pub enum Event {
     /// A new client connects. Clients are uniquely identified by the ip:port combination at this layer.
-    Connected{ conn: Arc<Connection> },
+    Connected(Arc<RwLock<Connection>>),
     /// A client disconnects. This can be generated from the server-side intentionally disconnecting a client,
     /// or it could be from the client disconnecting.
-    Disconnected{ conn: Arc<Connection> },
+    Disconnected(Arc<RwLock<Connection>>),
     /// This is generated if the server has not seen traffic from a client for a configurable amount of time.
-    TimedOut{ conn: Arc<Connection> },
+    TimedOut(Arc<RwLock<Connection>>),
     /// This is generated when there is a change in the connection quality of a client.
-    QualityChange{ conn: Arc<Connection>, from: Quality, to: Quality },
+    QualityChange {
+        conn: Arc<RwLock<Connection>>,
+        from: Quality,
+        to: Quality,
+    },
 }
 
 #[cfg(test)]
 mod test {
-    use super::ConnectionEvent;
+    use super::Event;
     use net::Connection;
-    use std::sync::Arc;
     use std::net::ToSocketAddrs;
+    use std::sync::{Arc, RwLock};
 
     static TEST_HOST_IP: &'static str = "127.0.0.1";
     static TEST_PORT: &'static str = "20000";
@@ -29,7 +33,7 @@ mod test {
     fn test_create_event() {
         let addr = format!("{}:{}", TEST_HOST_IP, TEST_PORT).to_socket_addrs();
         let mut addr = addr.unwrap();
-        let test_conn = Arc::new(Connection::new(addr.next().unwrap()));
-        let _ = ConnectionEvent::Connected{conn: test_conn};
+        let test_conn = Arc::new(RwLock::new(Connection::new(addr.next().unwrap())));
+        let _ = Event::Connected(test_conn);
     }
 }

--- a/src/net/socket_state.rs
+++ b/src/net/socket_state.rs
@@ -1,12 +1,14 @@
 use std::collections::HashMap;
+use std::sync::mpsc::{self, Receiver, Sender};
 use std::sync::{Arc, RwLock};
 use std::thread;
 use std::time::Duration;
 
-use packet::{Packet, PacketData};
-use packet::header::{FragmentHeader, PacketHeader};
-use net::{Connection,SocketAddr, NetworkConfig};
 use error::{NetworkError, Result};
+use events::Event;
+use net::{Connection, NetworkConfig, SocketAddr};
+use packet::header::{FragmentHeader, PacketHeader};
+use packet::{Packet, PacketData};
 use total_fragments_needed;
 
 // Type aliases
@@ -24,17 +26,22 @@ const TIMEOUT_POLL_INTERVAL: u64 = 1;
 pub struct SocketState {
     timeout: ConnectionTimeout,
     connections: ConnectionMap,
-    timeout_check_thread: thread::JoinHandle<()>
+    timeout_check_thread: thread::JoinHandle<()>,
+    events: (Sender<Event>, Receiver<Event>),
 }
 
 impl SocketState {
     pub fn new() -> Result<SocketState> {
         let connections: ConnectionMap = Arc::new(RwLock::new(HashMap::new()));
-        let thread_handle = SocketState::check_for_timeouts(connections.clone())?;
+        let (tx, rx) = mpsc::channel();
+
+        let thread_handle = SocketState::check_for_timeouts(connections.clone(), tx.clone())?;
+
         Ok(SocketState {
             connections: Arc::new(RwLock::new(HashMap::new())),
             timeout: TIMEOUT_DEFAULT,
-            timeout_check_thread: thread_handle
+            timeout_check_thread: thread_handle,
+            events: (tx, rx),
         })
     }
 
@@ -44,14 +51,21 @@ impl SocketState {
     }
 
     /// This will initialize the seq number, ack number and give back the raw data of the packet with the updated information.
-    pub fn pre_process_packet(&mut self, packet: Packet, config: &NetworkConfig) ->  Result<(SocketAddr, PacketData)>  {
-
+    pub fn pre_process_packet(
+        &mut self,
+        packet: Packet,
+        config: &NetworkConfig,
+    ) -> Result<(SocketAddr, PacketData)> {
         if packet.payload().len() > config.max_packet_size {
-            error!("Packet too large: Attempting to send {}, max={}", packet.payload().len(), config.max_packet_size);
+            error!(
+                "Packet too large: Attempting to send {}, max={}",
+                packet.payload().len(),
+                config.max_packet_size
+            );
             return Err(NetworkError::ExceededMaxPacketSize.into());
         }
 
-        let connection = self.create_connection_if_not_exists(&packet.addr())?;
+        let connection = self.get_connection_or_insert(&packet.addr())?;
 
         let mut connection_seq: u16 = 0;
         let mut their_last_seq: u16 = 0;
@@ -81,7 +95,7 @@ impl SocketState {
         // spit the packet if the payload lenght is greater than the allowrd fragment size.
         if payload_length <= config.fragment_size {
             packet_data.add_fragment(&packet_header, payload.to_vec());
-        }else {
+        } else {
             let num_fragments = total_fragments_needed(payload_length, config.fragment_size) as u8; /* safe cast max fragments is u8 */
 
             if num_fragments > config.max_fragments {
@@ -89,7 +103,8 @@ impl SocketState {
             }
 
             for fragment_id in 0..num_fragments {
-                let fragment = FragmentHeader::new(fragment_id, num_fragments, packet_header.clone());
+                let fragment =
+                    FragmentHeader::new(fragment_id, num_fragments, packet_header.clone());
 
                 // get start end pos in buffer
                 let start_fragment_pos = fragment_id as u16 * config.fragment_size; /* upcast is safe */
@@ -101,7 +116,8 @@ impl SocketState {
                 }
 
                 // get specific slice of data for fragment
-                let fragment_data = &payload[start_fragment_pos as usize..end_fragment_pos as usize]; /* upcast is safe */
+                let fragment_data =
+                    &payload[start_fragment_pos as usize..end_fragment_pos as usize]; /* upcast is safe */
 
                 packet_data.add_fragment(&fragment, fragment_data.to_vec());
             }
@@ -118,7 +134,7 @@ impl SocketState {
 
     /// This will return all dropped packets from this connection.
     pub fn dropped_packets(&mut self, addr: SocketAddr) -> Result<Vec<Packet>> {
-        let connection = self.create_connection_if_not_exists(&addr)?;
+        let connection = self.get_connection_or_insert(&addr)?;
         let mut lock = connection
             .write()
             .map_err(|_| NetworkError::AddConnectionToManagerFailed)?;
@@ -128,9 +144,8 @@ impl SocketState {
     }
 
     /// This will process an incoming packet and update acknowledgement information.
-    pub fn process_received(&mut self, addr: SocketAddr, packet: &PacketHeader) -> Result<()>{
-        let connection = self.create_connection_if_not_exists(&addr)?;
-
+    pub fn process_received(&mut self, addr: SocketAddr, packet: &PacketHeader) -> Result<()> {
+        let connection = self.get_connection_or_insert(&addr)?;
         let mut lock = connection
             .write()
             .map_err(|_| NetworkError::AddConnectionToManagerFailed)?;
@@ -147,68 +162,99 @@ impl SocketState {
         Ok(())
     }
 
+    /// This will return a `Vec` of events for processing.
+    pub fn events(&self) -> Vec<Event> {
+        let (_, ref rx) = self.events;
+
+        rx.try_iter().collect()
+    }
+
+    // Wrapper around getting the events sender
+    // This will cause a clone to be done, but this is low cost
+    fn get_events_sender(&self) -> Sender<Event> {
+        self.events.0.clone()
+    }
+
     // This function starts a background thread that does the following:
     // 1. Gets a read lock on the HashMap containing all the connections
     // 2. Iterate through each one
     // 3. Check if the last time we have heard from them (received a packet from them) is greater than the amount of time considered to be a timeout
     // 4. If they have timed out, send a notification up the stack
-    fn check_for_timeouts(connections: ConnectionMap) -> Result<thread::JoinHandle<()>> {
+    fn check_for_timeouts(
+        connections: ConnectionMap,
+        events_sender: Sender<Event>,
+    ) -> Result<thread::JoinHandle<()>> {
         let sleepy_time = Duration::from_secs(TIMEOUT_DEFAULT);
         let poll_interval = Duration::from_secs(TIMEOUT_POLL_INTERVAL);
 
         Ok(thread::Builder::new()
             .name("check_for_timeouts".into())
             .spawn(move || loop {
-                
-                    trace!("Checking for timeouts");
-                    match connections.read() {
-                        Ok(lock) => {
-                            for (key, value) in lock.iter() {
-                                if let Ok(c) = value.read() {
-                                    if c.last_heard() >= sleepy_time {
-                                        // TODO: pass up client TimedOut event
-                                        error!("Client has timed out: {:?}", key);
-                                    }
+                trace!("Checking for timeouts");
+                match connections.read() {
+                    Ok(lock) => {
+                        for (key, value) in lock.iter() {
+                            if let Ok(c) = value.read() {
+                                if c.last_heard() >= sleepy_time {
+                                    let event = Event::TimedOut(value.clone());
+
+                                    events_sender
+                                        .send(event)
+                                        .expect("Unable to send disconnect event");
+
+                                    debug!("Client has timed out: {:?}", key);
                                 }
                             }
-                        },
-                        Err(_e) => {
-                            error!("Unable to acquire read lock to check for timed out connections")
                         }
                     }
+                    Err(_e) => {
+                        error!("Unable to acquire read lock to check for timed out connections")
+                    }
+                }
 
                 thread::sleep(poll_interval);
-            })?
-        )
+            })?)
     }
 
-    #[inline]
     /// If there is no connection with the given socket address an new connection will be made.
-    fn create_connection_if_not_exists(
-        &mut self,
-        addr: &SocketAddr,
-    ) -> Result<Arc<RwLock<Connection>>> {
-        let mut lock = self
-            .connections
-            .write()
-            .map_err(|_| NetworkError::AddConnectionToManagerFailed)?;
+    fn get_connection_or_insert(&mut self, addr: &SocketAddr) -> Result<Arc<RwLock<Connection>>> {
+        let connection = {
+            let lock = self
+                .connections
+                .read()
+                .map_err(|_| NetworkError::AddConnectionToManagerFailed)?;
 
-        let connection = lock
-            .entry(*addr)
-            .or_insert_with(|| Arc::new(RwLock::new(Connection::new(*addr))));
+            lock.get(addr).map(|conn| conn.clone())
+        };
 
-        Ok(connection.clone())
+        match connection {
+            Some(connection) => Ok(connection),
+            None => {
+                let mut lock = self
+                    .connections
+                    .write()
+                    .map_err(|_| NetworkError::AddConnectionToManagerFailed)?;
+
+                let connection = Arc::new(RwLock::new(Connection::new(*addr)));
+                let event = Event::Connected(connection.clone());
+
+                self.get_events_sender().send(event)?;
+                lock.insert(*addr, connection.clone());
+
+                Ok(connection)
+            }
+        }
     }
 }
 
 #[cfg(test)]
 mod test {
-    use net::{Connection, NetworkConfig, SocketState, constants};
+    use net::{constants, Connection, NetworkConfig, SocketState};
+    use packet::header::{FragmentHeader, HeaderReader, PacketHeader};
     use packet::{Packet, PacketData};
-    use packet::header::{FragmentHeader, PacketHeader, HeaderReader};
 
     use std::io::Cursor;
-    use std::net::{ToSocketAddrs, SocketAddr, IpAddr};
+    use std::net::{IpAddr, SocketAddr, ToSocketAddrs};
     use std::str::FromStr;
     use std::{thread, time};
 
@@ -223,7 +269,7 @@ mod test {
         let addr = format!("{}:{}", TEST_HOST_IP, TEST_PORT).to_socket_addrs();
         assert!(addr.is_ok());
         let mut addr = addr.unwrap();
-        let new_conn = Connection::new(addr.next().unwrap());
+        let _ = Connection::new(addr.next().unwrap());
     }
 
     #[test]
@@ -239,31 +285,34 @@ mod test {
     }
 
     #[test]
-    pub fn construct_packet_less_than_mtu()
-    {
+    pub fn construct_packet_less_than_mtu() {
         let config = NetworkConfig::default();
 
         // - 1 so that packet can fit inside one fragment.
         let mut data = vec![0; config.fragment_size as usize - 1];
 
         // do some test processing of the data.
-        let mut processed_packet: (SocketAddr, PacketData) = simulate_packet_processing(data.clone(), &config);
+        let mut processed_packet: (SocketAddr, PacketData) =
+            simulate_packet_processing(data.clone(), &config);
 
         // check that there is only one fragment and that the data is right.
         assert_eq!(processed_packet.1.fragment_count(), 1);
-        assert_eq!(processed_packet.1.parts()[0].len(), data.len() + (constants::PACKET_HEADER_SIZE as usize));
+        assert_eq!(
+            processed_packet.1.parts()[0].len(),
+            data.len() + (constants::PACKET_HEADER_SIZE as usize)
+        );
     }
 
     #[test]
-    pub fn construct_packet_greater_than_mtu()
-    {
+    pub fn construct_packet_greater_than_mtu() {
         let config = NetworkConfig::default();
 
-        /// test data
+        // test data
         let data = vec![0; config.fragment_size as usize * 4];
 
         // do some test processing of the data.
-        let mut processed_packet: (SocketAddr, PacketData) = simulate_packet_processing(data.clone(), &config);
+        let mut processed_packet: (SocketAddr, PacketData) =
+            simulate_packet_processing(data.clone(), &config);
 
         let num_fragments = total_fragments_needed(data.len() as u16, config.fragment_size);
 
@@ -271,16 +320,19 @@ mod test {
         assert_eq!(processed_packet.1.fragment_count(), num_fragments as usize);
 
         // check if the first packet also contains the fragment header and packet header
-        assert_eq!(processed_packet.1.parts()[0].len() ,((constants::PACKET_HEADER_SIZE + constants::FRAGMENT_HEADER_SIZE) as u16 + config.fragment_size) as usize);
+        assert_eq!(
+            processed_packet.1.parts()[0].len(),
+            ((constants::PACKET_HEADER_SIZE + constants::FRAGMENT_HEADER_SIZE) as u16
+                + config.fragment_size) as usize
+        );
     }
 
     #[test]
-    pub fn construct_packet_and_reassemble_less_than_mtu()
-    {
+    pub fn construct_packet_and_reassemble_less_than_mtu() {
         let config = NetworkConfig::default();
 
         // - 1 so that packet can fit inside one fragment.
-        let data = vec![0; config.fragment_size as usize  - 1];
+        let data = vec![0; config.fragment_size as usize - 1];
 
         // do some test processing of the data.
         let mut processed_packet = simulate_packet_processing(data.clone(), &config);
@@ -293,11 +345,10 @@ mod test {
     }
 
     #[test]
-    pub fn construct_packet_and_reassemble_greater_than_mtu()
-    {
+    pub fn construct_packet_and_reassemble_greater_than_mtu() {
         let config = NetworkConfig::default();
 
-        /// test data
+        // test data
         let data = vec![0; config.fragment_size as usize * 4];
 
         // do some test processing of the data.
@@ -310,14 +361,16 @@ mod test {
 
             if prefix & 1 == 0 {
                 assert!(FragmentHeader::read(&mut cursor).is_ok())
-            }else {
+            } else {
                 assert!(FragmentHeader::read(&mut cursor).is_ok())
             }
         }
     }
 
-    fn simulate_packet_processing(data: Vec<u8>, config: &NetworkConfig) -> (SocketAddr, PacketData)
-    {
+    fn simulate_packet_processing(
+        data: Vec<u8>,
+        config: &NetworkConfig,
+    ) -> (SocketAddr, PacketData) {
         // create packet with test data
         let packet = Packet::new(get_dummy_socket_addr(), data.clone());
 
@@ -327,8 +380,7 @@ mod test {
         result.unwrap()
     }
 
-    fn get_dummy_socket_addr() -> SocketAddr
-    {
+    fn get_dummy_socket_addr() -> SocketAddr {
         SocketAddr::new(
             IpAddr::from_str("127.0.0.1").expect("Unreadable input IP."),
             12348,

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -1,8 +1,9 @@
 use std::net::{self, ToSocketAddrs};
 
-use packet::{Packet, PacketProcessor};
-use net::{NetworkConfig, SocketState};
 use error::{NetworkError, Result};
+use events::Event;
+use net::{NetworkConfig, SocketState};
+use packet::{Packet, PacketProcessor};
 
 /// Maximum amount of data that we can read from a datagram
 const BUFFER_SIZE: usize = 1024;
@@ -13,7 +14,7 @@ pub struct UdpSocket {
     state: SocketState,
     recv_buffer: Vec<u8>,
     config: NetworkConfig,
-    packet_processor: PacketProcessor
+    packet_processor: PacketProcessor,
 }
 
 impl UdpSocket {
@@ -25,7 +26,7 @@ impl UdpSocket {
         Ok(UdpSocket {
             socket,
             state,
-            recv_buffer: vec![0;config.receive_buffer_max_size],
+            recv_buffer: vec![0; config.receive_buffer_max_size],
             packet_processor: PacketProcessor::new(config.clone()),
             config,
         })
@@ -33,14 +34,18 @@ impl UdpSocket {
 
     /// Receives a single datagram message on the socket. On success, returns the packet containing origin and data.
     pub fn recv(&mut self) -> Result<Option<Packet>> {
-        let (len, addr) = self.socket.recv_from(&mut self.recv_buffer).map_err(|_| NetworkError::ReceiveFailed)?;
+        let (len, addr) = self
+            .socket
+            .recv_from(&mut self.recv_buffer)
+            .map_err(|_| NetworkError::ReceiveFailed)?;
 
         if len > 0 {
             let packet = self.recv_buffer[..len].to_owned();
 
-            self.packet_processor.process_data(packet, addr, &mut self.state)
-        }else {
-            return Err (NetworkError::ReceiveFailed.into());
+            self.packet_processor
+                .process_data(packet, addr, &mut self.state)
+        } else {
+            return Err(NetworkError::ReceiveFailed.into());
         }
     }
 
@@ -51,29 +56,32 @@ impl UdpSocket {
         let mut bytes_sent = 0;
 
         for payload in packet_data.parts() {
-            bytes_sent += self.socket.send_to(&payload, addr).map_err(|_| NetworkError::SendFailed)?;
+            bytes_sent += self
+                .socket
+                .send_to(&payload, addr)
+                .map_err(|_| NetworkError::SendFailed)?;
         }
 
         Ok(bytes_sent)
     }
 
+    pub fn events(&self) -> Vec<Event> {
+        self.state.events()
+    }
+
     /// Sets the blocking mode of the socket. In non-blocking mode, recv_from will not block if there is no data to be read. In blocking mode, it will. If using non-blocking mode, it is important to wait some amount of time between iterations, or it will quickly use all CPU available
     pub fn set_nonblocking(&mut self, nonblocking: bool) -> Result<()> {
         match self.socket.set_nonblocking(nonblocking) {
-            Ok(_) => {
-                Ok(())
-            }
-            Err(_e) => {
-                Err(NetworkError::UnableToSetNonblocking.into())
-            }
+            Ok(_) => Ok(()),
+            Err(_e) => Err(NetworkError::UnableToSetNonblocking.into()),
         }
     }
 }
 
 #[cfg(test)]
 mod test {
-    use net::{UdpSocket, NetworkConfig, constants};
     use bincode::{deserialize, serialize};
+    use net::{constants, NetworkConfig, UdpSocket};
     use packet::Packet;
     use std::io;
     use std::net::{IpAddr, SocketAddr};
@@ -83,8 +91,8 @@ mod test {
     #[test]
     #[ignore]
     fn send_receive_1_pckt() {
-        let mut send_socket = UdpSocket::bind("127.0.0.1:12347",NetworkConfig::default()).unwrap();
-        let mut recv_socket = UdpSocket::bind("127.0.0.1:12348",NetworkConfig::default()).unwrap();
+        let mut send_socket = UdpSocket::bind("127.0.0.1:12347", NetworkConfig::default()).unwrap();
+        let mut recv_socket = UdpSocket::bind("127.0.0.1:12348", NetworkConfig::default()).unwrap();
 
         let addr = "127.0.0.1:12348".parse().unwrap();
 
@@ -106,28 +114,28 @@ mod test {
     #[test]
     #[ignore]
     fn send_receive_fragment_packet() {
-        let mut send_socket = UdpSocket::bind("127.0.0.1:12347",NetworkConfig::default()).unwrap();
-        let mut recv_socket = UdpSocket::bind("127.0.0.1:12348",NetworkConfig::default()).unwrap();
+        let mut send_socket = UdpSocket::bind("127.0.0.1:12347", NetworkConfig::default()).unwrap();
+        let mut recv_socket = UdpSocket::bind("127.0.0.1:12348", NetworkConfig::default()).unwrap();
 
         let addr = "127.0.0.1:12348".parse().unwrap();
 
-        let handle = thread::spawn(move || {
-            loop {
-                let packet = recv_socket.recv();
+        let handle = thread::spawn(move || loop {
+            let packet = recv_socket.recv();
 
-                match packet {
-                    Ok(Some(packet)) => {
-                        assert_eq!(packet.addr().to_string(), "127.0.0.1:12347");
-                        assert_eq!(packet.payload(), vec![123; 4000].as_slice());
-                        break;
-                    }
-                    Err(e) => { panic!("{:?}",e); },
-                    _ => { }
-                };
-            }
+            match packet {
+                Ok(Some(packet)) => {
+                    assert_eq!(packet.addr().to_string(), "127.0.0.1:12347");
+                    assert_eq!(packet.payload(), vec![123; 4000].as_slice());
+                    break;
+                }
+                Err(e) => {
+                    panic!("{:?}", e);
+                }
+                _ => {}
+            };
         });
 
-        let dummy_packet = Packet::new(addr, vec![123;4000]);
+        let dummy_packet = Packet::new(addr, vec![123; 4000]);
         let send_result = send_socket.send(dummy_packet);
         assert!(send_result.is_ok());
 
@@ -142,12 +150,12 @@ mod test {
         thread::spawn(|| {
             thread::sleep(time::Duration::from_millis(3));
 
-            let mut send_socket = UdpSocket::bind("127.0.0.1:12357",NetworkConfig::default()).unwrap();
+            let mut send_socket =
+                UdpSocket::bind("127.0.0.1:12357", NetworkConfig::default()).unwrap();
 
             let addr = "127.0.0.1:12358".parse().unwrap();
 
             for packet_count in 0..TOTAL_PACKAGES {
-
                 let stub = StubData {
                     id: packet_count,
                     b: 400,
@@ -159,15 +167,19 @@ mod test {
                 let dummy_packet = Packet::new(addr, data);
                 let send_result = send_socket.send(dummy_packet);
                 assert!(send_result.is_ok());
-                assert_eq!(send_result.unwrap(), len + constants::PACKET_HEADER_SIZE as usize);
+                assert_eq!(
+                    send_result.unwrap(),
+                    len + constants::PACKET_HEADER_SIZE as usize
+                );
             }
         });
 
         thread::spawn(|| {
-            let mut recv_socket = UdpSocket::bind("127.0.0.1:12358", NetworkConfig::default()).unwrap();
+            let mut recv_socket =
+                UdpSocket::bind("127.0.0.1:12358", NetworkConfig::default()).unwrap();
             let mut received_packages_count = 0;
             loop {
-                let packet= recv_socket.recv();
+                let packet = recv_socket.recv();
                 assert!(packet.is_ok());
 
                 let packet_payload: Option<Packet> = packet.unwrap();


### PR DESCRIPTION
This adds `Event` production to socket state. This is done via a mpsc
channel that can be consumed via `SocketState::events` which will
return a `Vec<Event>` to be consumed up the stack. This setup will
allow the `UdpSocket` to return this `Vec<Event>` back up to the user
to handle when the time is right in their implementation.

Other notable changes:
- Simple rustfmt on socket_state, udp, and events.
- Moved `Connected`, `Disconnected` and `TimedOut` to be a single
tuple of `Arc<RwLock<Connection>>` for clairty.
- Renamed `SocketState::create_connection_if_exists` to
`SocketState::get_connection_or_insert` also improved the way we use
locks in this. Since most calls to this function just needs a read
lock and not a write lock. A read lock is aquired initally to check if
there is a connection or not. If there is not, it will drop the read
lock and aquire a write lock to insert the new connection. At this
point it will also create a `Connected` event.

This PR is in reference to #11 