### PR TITLE
Implemented Connection Pool.

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -1,28 +1,28 @@
 use std::sync::{Arc, RwLock};
 
-use net::{Connection, Quality};
+use net::{VirtualConnection, NetworkQuality};
 
 /// Events that are generated in response to a change in state of the connected client
 pub enum Event {
     /// A new client connects. Clients are uniquely identified by the ip:port combination at this layer.
-    Connected(Arc<RwLock<Connection>>),
+    Connected(Arc<RwLock<VirtualConnection>>),
     /// A client disconnects. This can be generated from the server-side intentionally disconnecting a client,
     /// or it could be from the client disconnecting.
-    Disconnected(Arc<RwLock<Connection>>),
+    Disconnected(Arc<RwLock<VirtualConnection>>),
     /// This is generated if the server has not seen traffic from a client for a configurable amount of time.
-    TimedOut(Arc<RwLock<Connection>>),
+    TimedOut(Arc<RwLock<VirtualConnection>>),
     /// This is generated when there is a change in the connection quality of a client.
     QualityChange {
-        conn: Arc<RwLock<Connection>>,
-        from: Quality,
-        to: Quality,
+        conn: Arc<RwLock<VirtualConnection>>,
+        from: NetworkQuality,
+        to: NetworkQuality,
     },
 }
 
 #[cfg(test)]
 mod test {
     use super::Event;
-    use net::Connection;
+    use net::VirtualConnection;
     use std::net::ToSocketAddrs;
     use std::sync::{Arc, RwLock};
 
@@ -33,7 +33,8 @@ mod test {
     fn test_create_event() {
         let addr = format!("{}:{}", TEST_HOST_IP, TEST_PORT).to_socket_addrs();
         let mut addr = addr.unwrap();
-        let test_conn = Arc::new(RwLock::new(Connection::new(addr.next().unwrap())));
+
+        let test_conn = Arc::new(RwLock::new(VirtualConnection::new(addr.next().unwrap())));
         let _ = Event::Connected(test_conn);
     }
 }

--- a/src/net/connection/connection_pool.rs
+++ b/src/net/connection/connection_pool.rs
@@ -1,0 +1,103 @@
+use super::VirtualConnection;
+use error::{NetworkError, Error,Result};
+use events::Event;
+
+use std::thread;
+use std::sync::mpsc::Sender;
+use std::time::Duration;
+use std::sync::{Arc, Mutex, RwLock, RwLockWriteGuard};
+use std::net::{SocketAddr};
+use std::collections::HashMap;
+
+type Connection = Arc<RwLock<VirtualConnection>>;
+type Connections = HashMap<SocketAddr, Connection>;
+type ConnectionsCollection = Arc<RwLock<Connections>>;
+
+// Default time between checks of all clients for timeouts in seconds
+const TIMEOUT_POLL_INTERVAL: u64 = 1;
+
+/// This is an pool of virtual connections (connected) over UDP.
+pub struct ConnectionPool
+{
+    timeout: Duration,
+    connections: ConnectionsCollection,
+    sleepy_time: Duration,
+    poll_interval: Duration,
+}
+
+impl ConnectionPool {
+    pub fn new() -> ConnectionPool
+    {
+        let sleepy_time = Duration::from_secs(1);
+        let poll_interval = Duration::from_secs(TIMEOUT_POLL_INTERVAL);
+
+        ConnectionPool { timeout: Duration::from_secs(1), connections: Arc::new(RwLock::new(HashMap::new())), sleepy_time, poll_interval }
+    }
+
+    /// Set the timeout before an client will be seen as disconnected.
+    pub fn set_timeout(&mut self, timeout: Duration)
+    {
+        self.timeout = timeout;
+    }
+
+    /// Insert connection if it does not exists.
+    pub fn get_connection_or_insert(&mut self, addr: &SocketAddr) -> Result<Connection> {
+        let mut lock = self
+            .connections
+            .write()
+            .map_err(|_| NetworkError::AddConnectionToManagerFailed)?;
+
+        let connection = lock
+            .entry(*addr)
+            .or_insert_with(|| Arc::new(RwLock::new(VirtualConnection::new(*addr))));
+
+        Ok(connection.clone())
+    }
+
+    /// Start loop that will detect if connections will are disconnected.
+    ///
+    /// This function starts a background thread that does the following:
+    /// 1. Gets a read lock on the HashMap containing all the connections
+    /// 2. Iterate through each one
+    /// 3. Check if the last time we have heard from them (received a packet from them) is greater than the amount of time considered to be a timeout
+    /// 4. If they have timed out, send a notification up the stack
+    pub fn start_time_out_loop(&self, events_sender: Sender<Event>) -> Result<thread::JoinHandle<()>>
+    {
+        let connections = self.connections.clone();
+        let poll_interval = self.poll_interval;
+        let mut sender = events_sender;
+
+        Ok(thread::Builder::new()
+            .name("check_for_timeouts".into())
+            .spawn(move ||
+                loop {
+                    match connections.read() {
+                        Ok(lock) => {
+                            ConnectionPool::check_for_timeouts(&*lock, poll_interval, &mut sender);
+                        },
+                        Err(e) => {
+                            error!("Unable to acquire read lock to check for timed out connections")
+                        }
+                    }
+                    thread::sleep(poll_interval);
+                })?
+        )
+    }
+
+    /// Check if there are any connections that have not been active for the given Duration.
+    fn check_for_timeouts(connections: &Connections, sleepy_time: Duration, events_sender: &mut Sender<Event>) {
+        for (key, value) in connections.iter() {
+            if let Ok(c) = value.read() {
+                if c.last_heard() >= sleepy_time {
+                    let event = Event::TimedOut(value.clone());
+
+                    events_sender
+                        .send(event)
+                        .expect("Unable to send disconnect event");
+
+                    error!("Client has timed out: {:?}", key);
+                }
+            }
+        }
+    }
+}

--- a/src/net/connection/mod.rs
+++ b/src/net/connection/mod.rs
@@ -1,0 +1,12 @@
+use std::sync::{Arc, Mutex, RwLock};
+use std::net::{SocketAddr};
+use std::collections::HashMap;
+
+mod virtual_connection;
+mod connection_pool;
+mod quality;
+
+pub use self::virtual_connection::VirtualConnection;
+pub use self::connection_pool::ConnectionPool;
+pub use self::quality::NetworkQuality;
+

--- a/src/net/connection/quality.rs
+++ b/src/net/connection/quality.rs
@@ -1,0 +1,28 @@
+// TODO: Congestion avoidance.
+// To prevent congestion avoidance we need ot decide whether the connection is good or bad.
+// If the network of the client is bad we do not flood the router with small packets.
+// When network conditions are `Good` we send 30 packets per-second, and when network conditions are `Bad` we drop to 10 packets per-second.
+
+/// Represents the quality of an network.
+pub enum NetworkQuality {
+    Good,
+    Bad,
+}
+
+#[cfg(test)]
+mod test {
+    use net::connection::VirtualConnection;
+    use std::net::ToSocketAddrs;
+
+    static TEST_HOST_IP: &'static str = "127.0.0.1";
+    static TEST_BAD_HOST_IP: &'static str = "800.0.0.1";
+    static TEST_PORT: &'static str = "20000";
+
+    #[test]
+    fn test_create_connection() {
+        let mut addr = format!("{}:{}", TEST_HOST_IP, TEST_PORT)
+            .to_socket_addrs()
+            .unwrap();
+        let _new_conn = VirtualConnection::new(addr.next().unwrap());
+    }
+}

--- a/src/net/connection/virtual_connection.rs
+++ b/src/net/connection/virtual_connection.rs
@@ -1,4 +1,4 @@
-use super::{ExternalAcks, LocalAckRecord};
+use net::{ExternalAcks, LocalAckRecord, NetworkQuality};
 use packet::Packet;
 use std::fmt;
 use std::net::SocketAddr;
@@ -6,26 +6,26 @@ use std::time::{Duration, Instant};
 
 /// Contains the information about a certain 'virtual connection' over udp.
 /// This stores information about the last sequence number, dropped packages, packages waiting for acknowledgement and acknowledgements gotten from the other side.
-pub struct Connection {
+pub struct VirtualConnection {
     pub seq_num: u16,
     pub dropped_packets: Vec<Packet>,
     pub waiting_packets: LocalAckRecord,
     pub their_acks: ExternalAcks,
     pub last_heard: Instant,
     pub remote_address: SocketAddr,
-    pub quality: Quality,
+    pub quality: NetworkQuality,
 }
 
-impl Connection {
+impl VirtualConnection {
     /// Creates and returns a new Connection that wraps the provided socket address
-    pub fn new(addr: SocketAddr) -> Connection {
-        Connection {
+    pub fn new(addr: SocketAddr) -> VirtualConnection {
+        VirtualConnection {
             seq_num: 0,
             dropped_packets: Vec::new(),
             waiting_packets: Default::default(),
             their_acks: Default::default(),
             last_heard: Instant::now(),
-            quality: Quality::Good,
+            quality: NetworkQuality::Good,
             remote_address: addr,
         }
     }
@@ -37,7 +37,7 @@ impl Connection {
     }
 }
 
-impl fmt::Debug for Connection {
+impl fmt::Debug for VirtualConnection {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
@@ -45,33 +45,5 @@ impl fmt::Debug for Connection {
             self.remote_address.ip(),
             self.remote_address.port()
         )
-    }
-}
-
-// TODO:
-/// This defines whether the connection is good or bad.
-/// We should use this for handling Congestion Avoidance so that when the network of the client is bad we do not flood the router with small packets.
-///
-/// When network conditions are `Good` we send 30 packets per-second, and when network conditions are `Bad` we drop to 10 packets per-second.
-pub enum Quality {
-    Good,
-    Bad,
-}
-
-#[cfg(test)]
-mod test {
-    use net::connection::Connection;
-    use std::net::ToSocketAddrs;
-
-    static TEST_HOST_IP: &'static str = "127.0.0.1";
-    static TEST_BAD_HOST_IP: &'static str = "800.0.0.1";
-    static TEST_PORT: &'static str = "20000";
-
-    #[test]
-    fn test_create_connection() {
-        let mut addr = format!("{}:{}", TEST_HOST_IP, TEST_PORT)
-            .to_socket_addrs()
-            .unwrap();
-        let _new_conn = Connection::new(addr.next().unwrap());
     }
 }

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -9,11 +9,11 @@ mod udp;
 mod tcp;
 
 pub use self::network_config::NetworkConfig;
-pub use self::connection::{Connection, Quality};
+pub use self::connection::{VirtualConnection, NetworkQuality};
 pub use self::socket_state::SocketState;
 pub use self::udp::UdpSocket;
 pub use self::tcp::{TcpSocketState,TcpClient,TcpServer};
 pub use std::net::SocketAddr;
+pub use self::external_ack::ExternalAcks;
+pub use self::local_ack::LocalAckRecord;
 
-use self::external_ack::ExternalAcks;
-use self::local_ack::LocalAckRecord;


### PR DESCRIPTION
So in discord we spoke about refactoring `SocketState`.

I have moved all the connection logic from `SocketState` type to its own type. Now we have an `ConnectionPool` which will manage the virtual connections. 

So why this you may ask. Because we want to separate concerns here. And having connection logic appart from receving logic seems nice to me. And a nice beginning for refactoring `SocketState.`

I can make the connection pool generic to also support TCP connections but did not know if that was necessarily since TCP connections work differently. 