### PR TITLE
Added support for sending different kinds packets

### DIFF
--- a/examples/server_client.rs
+++ b/examples/server_client.rs
@@ -29,7 +29,7 @@ fn server() -> Result<()> {
 
                 println!("Received {:?} from {:?}", msg, ip);
 
-                socket.send(Packet::new(packet.addr(), "Copy that!".as_bytes().to_vec()))?;
+                socket.send(Packet::sequenced_unordered(packet.addr(), "Copy that!".as_bytes().to_vec()))?;
             }
             None => {}
         }
@@ -53,7 +53,7 @@ fn client() -> Result<()> {
         stdin.read_line(&mut s_buffer)?;
         let line = s_buffer.replace(|x| x == '\n' || x == '\r', "");
 
-        socket.send(Packet::new(server, line.clone().into_bytes()))?;
+        socket.send(Packet::sequenced_unordered(server, line.clone().into_bytes()))?;
 
         if line == "Bye!" {
             break;

--- a/examples/simple_udp.rs
+++ b/examples/simple_udp.rs
@@ -165,7 +165,7 @@ impl Client {
         match serialized {
             Ok(raw_data) => {
                 self.udp_socket
-                    .send(Packet::new(server_address(), raw_data));
+                    .send(Packet::sequenced_unordered(server_address(), raw_data));
             }
             Err(e) => println!("Some error occurred: {:?}", e),
         }

--- a/examples/udp.rs
+++ b/examples/udp.rs
@@ -118,7 +118,7 @@ pub fn construct_packet() -> Packet {
     let raw_data = "example data".as_bytes();
 
     // lets construct or packet by passing in the destination for this packet and the bytes needed to be send..
-    let packet: Packet = Packet::new(destination, raw_data.to_owned());
+    let packet: Packet = Packet::sequenced_unordered(destination, raw_data.to_owned());
 
     packet
 }

--- a/src/infrastructure/delivery_method.rs
+++ b/src/infrastructure/delivery_method.rs
@@ -1,0 +1,84 @@
+/// This enum defines on how an packet would be delivered to the other side.
+#[derive(Copy, Clone, Debug,PartialOrd, PartialEq, Eq)]
+pub enum DeliveryMethod
+{
+    /// Unreliable. Packets can be dropped, duplicated or arrive without order
+    ///
+    /// *Details*
+    ///
+    ///  1. Unreliable
+    ///  2. No guarantee for delivery.
+    ///  3. No guarantee for order.
+    ///  4. No way of getting dropped packet
+    ///  5. Duplication possible
+    ///
+    /// Basically just bare UDP
+    Unreliable,
+    /// Reliable. All packets will be sent and received, but without order
+    ///
+    /// *Details*
+    ///
+    ///  1. Reliable.
+    ///  2. Guarantee of delivery.
+    ///  3. No guarantee for order.
+    ///  4. Packets will not be dropped.
+    ///  5. Duplication not possible
+    ///
+    /// Basically this is almost TCP like without ordering of packets.
+    ReliableUnordered,
+    /// Unreliable. Packets can be dropped, but never duplicated and arrive in order
+    ///
+    /// This will create an reliable ordered packet.
+    ///
+    /// *Details*
+    ///
+    ///  1. Unreliable.
+    ///  2. No guarantee of delivery.
+    ///  3. Guarantee for order.
+    ///  4. Packets can be dropped but you will be able to retrieve dropped packets.
+    ///  5. Duplication not possible
+    ///
+    /// Basically this is UDP with the ability to retrieve dropped packets by acknowledgements.
+    SequencedOrdered,
+    /// Unreliable. Packets can be dropped, and arrive out of order but you will be able to retrieve dropped packet.
+    ///
+    /// *Details*
+    ///
+    ///  1. Unreliable.
+    ///  2. No guarantee of delivery.
+    ///  3. No Guarantee for order.
+    ///  4. Packets can be dropped but you will be able to retrieve dropped packets.
+    ///  5. Duplication not possible
+    ///
+    /// Basically this is UDP with the ability to retrieve dropped packets by acknowledgements.
+    SequencedUnordered,
+    /// *Details*
+    ///
+    ///  1. Reliable.
+    ///  2. Guarantee of delivery.
+    ///  3. Guarantee for order.
+    ///  4. Packets will not be dropped.
+    ///  5. Duplication not possible
+    ///
+    /// Basically this is almost TCP like with ordering of packets.
+    ReliableOrdered,
+}
+
+impl DeliveryMethod {
+    /// Get integer value from `DeliveryMethod` enum.
+    pub fn get_delivery_method_id(delivery_method: DeliveryMethod) -> u8 {
+        delivery_method as u8
+    }
+
+    /// Get `DeliveryMethod` enum instance from integer value.
+    pub fn get_delivery_method_from_id(delivery_method_id: u8) -> DeliveryMethod {
+        match delivery_method_id {
+            0 => DeliveryMethod::Unreliable,
+            1 => DeliveryMethod::ReliableUnordered,
+            2 => DeliveryMethod::ReliableOrdered,
+            3 => DeliveryMethod::SequencedOrdered,
+            4 => DeliveryMethod::SequencedOrdered,
+            _ => DeliveryMethod::Unreliable
+        }
+    }
+}

--- a/src/infrastructure/mod.rs
+++ b/src/infrastructure/mod.rs
@@ -1,0 +1,5 @@
+///! Upcoming module where we should put all or infrastructure code like channels, packet processing etc.
+
+mod delivery_method;
+
+pub use self::delivery_method::DeliveryMethod;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub mod events;
 pub mod net;
 pub mod packet;
 mod sequence_buffer;
+mod infrastructure;
 
 /// This functions checks how many times a number fits into another number and will round up.
 ///

--- a/src/net/constants.rs
+++ b/src/net/constants.rs
@@ -1,5 +1,7 @@
 pub const FRAGMENT_HEADER_SIZE: u8 = 5;
-pub const PACKET_HEADER_SIZE: u8 = 9;
+pub const PACKET_HEADER_SIZE: u8 = 10;
+pub const HEART_BEAT_HEADER_SIZE: u8 = 1;
+
 pub const MAX_FRAGMENTS_DEFAULT: u16 = 16;
 pub const FRAGMENT_SIZE_DEFAULT: u16 = 1024;
 /// Maximum transmission unit of the payload.

--- a/src/net/local_ack.rs
+++ b/src/net/local_ack.rs
@@ -170,6 +170,6 @@ mod test {
             12345,
         );
 
-        Packet::new(addr, Vec::new())
+        Packet::sequenced_unordered(addr, Vec::new())
     }
 }

--- a/src/net/socket_state.rs
+++ b/src/net/socket_state.rs
@@ -81,7 +81,7 @@ impl SocketState {
 
         let mut packet_data = PacketData::new();
 
-        let packet_header = PacketHeader::new(connection_seq, their_last_seq, their_ack_field);
+        let packet_header = PacketHeader::new(connection_seq, their_last_seq, their_ack_field, packet.delivery_method());
 
         let payload = packet.payload();
         let payload_length = payload.len() as u16; /* safe cast because max packet size is u16 */
@@ -280,7 +280,7 @@ mod test {
         config: &NetworkConfig,
     ) -> (SocketAddr, PacketData) {
         // create packet with test data
-        let packet = Packet::new(get_dummy_socket_addr(), data.clone());
+        let packet = Packet::sequenced_unordered(get_dummy_socket_addr(), data.clone());
 
         // process the packet
         let mut socket_state = SocketState::new(&NetworkConfig::default()).unwrap();

--- a/src/packet/header/fragment.rs
+++ b/src/packet/header/fragment.rs
@@ -1,13 +1,14 @@
 use super::PacketHeader;
 use super::{HeaderParser, HeaderReader};
 use net::constants::FRAGMENT_HEADER_SIZE;
-
+use packet::PacketTypeId;
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use std::io::{self, Cursor, Error, ErrorKind, Write};
 
 #[derive(Copy, Clone, Debug)]
 /// This header represents an fragmented packet header.
 pub struct FragmentHeader {
+    packet_type_id: PacketTypeId,
     sequence: u16,
     id: u8,
     num_fragments: u8,
@@ -18,6 +19,7 @@ impl FragmentHeader {
     /// Create new fragment with the given packet header
     pub fn new(id: u8, num_fragments: u8, packet_header: PacketHeader) -> Self {
         FragmentHeader {
+            packet_type_id: PacketTypeId::Fragment,
             id,
             num_fragments,
             packet_header: Some(packet_header),
@@ -51,7 +53,7 @@ impl HeaderParser for FragmentHeader {
 
     fn parse(&self) -> <Self as HeaderParser>::Output {
         let mut wtr = Vec::new();
-        wtr.write_u8(1)?;
+        wtr.write_u8(PacketTypeId::get_id(self.packet_type_id))?;
         wtr.write_u16::<BigEndian>(self.sequence)?;
         wtr.write_u8(self.id)?;
         wtr.write_u8(self.num_fragments)?;
@@ -73,9 +75,9 @@ impl HeaderReader for FragmentHeader {
     type Header = io::Result<FragmentHeader>;
 
     fn read(rdr: &mut Cursor<Vec<u8>>) -> <Self as HeaderReader>::Header {
-        let prefix_byte = rdr.read_u8()?;
+        let packet_type_id = PacketTypeId::get_packet_type(rdr.read_u8()?);
 
-        if prefix_byte != 1 {
+        if packet_type_id != PacketTypeId::Fragment {
             return Err(Error::new(ErrorKind::Other, "Invalid fragment header"));
         }
 
@@ -84,6 +86,7 @@ impl HeaderReader for FragmentHeader {
         let num_fragments = rdr.read_u8()?;
 
         let mut header = FragmentHeader {
+            packet_type_id,
             sequence,
             id,
             num_fragments,
@@ -116,11 +119,12 @@ impl HeaderReader for FragmentHeader {
 mod tests {
     use byteorder::ReadBytesExt;
     use packet::header::{FragmentHeader, HeaderParser, HeaderReader, PacketHeader};
+    use infrastructure::DeliveryMethod;
     use std::io::Cursor;
 
     #[test]
     pub fn serializes_deserialize_fragment_header_test() {
-        let packet_header = PacketHeader::new(1, 1, 5421);
+        let packet_header = PacketHeader::new(1, 1, 5421, DeliveryMethod::Unreliable);
         let packet_serialized: Vec<u8> = packet_header.parse().unwrap();
 
         let fragment = FragmentHeader::new(0, 1, packet_header.clone());

--- a/src/packet/header/heart_beat.rs
+++ b/src/packet/header/heart_beat.rs
@@ -1,0 +1,58 @@
+use super::PacketHeader;
+use super::{HeaderParser, HeaderReader};
+use net::constants::{FRAGMENT_HEADER_SIZE, HEART_BEAT_HEADER_SIZE};
+use packet::PacketTypeId;
+use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
+use std::io::{self, Cursor, Error, ErrorKind, Write};
+
+#[derive(Copy, Clone, Debug)]
+/// This header represents an heartbeat packet header.
+/// An heart beat just keeps the client awake.
+pub struct HeartBeatHeader {
+    packet_type_id: PacketTypeId
+}
+
+impl HeartBeatHeader {
+    /// Create new heartbeat header.
+    pub fn new() -> Self {
+        HeartBeatHeader {
+            packet_type_id: PacketTypeId::HeartBeat
+        }
+    }
+}
+
+impl HeaderParser for HeartBeatHeader {
+    type Output = io::Result<Vec<u8>>;
+
+    fn parse(&self) -> <Self as HeaderParser>::Output {
+        let mut wtr = Vec::new();
+        wtr.write_u8(PacketTypeId::get_id(self.packet_type_id))?;
+
+        Ok(wtr)
+    }
+}
+
+impl HeaderReader for HeartBeatHeader {
+    type Header = io::Result<HeartBeatHeader>;
+
+    fn read(rdr: &mut Cursor<Vec<u8>>) -> <Self as HeaderReader>::Header {
+        let packet_type_id = PacketTypeId::get_packet_type(rdr.read_u8()?);
+
+        if packet_type_id != PacketTypeId::HeartBeat {
+            return Err(Error::new(ErrorKind::Other, "Invalid fragment header"));
+        }
+
+        let mut header = HeartBeatHeader {
+           packet_type_id
+        };
+
+        Ok(header)
+    }
+
+    /// Get the size of this header.
+    fn size(&self) -> u8 {
+       return HEART_BEAT_HEADER_SIZE;
+    }
+}
+
+

--- a/src/packet/header/mod.rs
+++ b/src/packet/header/mod.rs
@@ -1,9 +1,11 @@
-mod fragment;
 mod header_parser;
 mod header_reader;
 mod packet;
+mod fragment;
+mod heart_beat;
 
-pub use self::fragment::FragmentHeader;
 pub use self::header_parser::HeaderParser;
 pub use self::header_reader::HeaderReader;
 pub use self::packet::PacketHeader;
+pub use self::fragment::FragmentHeader;
+pub use self::heart_beat::HeartBeatHeader;

--- a/src/packet/mod.rs
+++ b/src/packet/mod.rs
@@ -4,8 +4,10 @@ mod packet;
 mod packet_data;
 mod packet_processor;
 mod raw_packet_data;
+mod packet_type;
 
 pub use self::packet_processor::PacketProcessor;
 pub use self::packet_data::PacketData;
 pub use self::raw_packet_data::RawPacketData;
 pub use self::packet::Packet;
+pub use self::packet_type::{PacketTypeId, PacketType};

--- a/src/packet/packet.rs
+++ b/src/packet/packet.rs
@@ -1,4 +1,5 @@
 use std::net::SocketAddr;
+use infrastructure::DeliveryMethod;
 
 #[derive(Clone, PartialEq, Eq, Debug)]
 /// This is a user friendly packet containing the payload from the packet and the enpoint from where it came.
@@ -7,14 +8,93 @@ pub struct Packet {
     addr: SocketAddr,
     // the raw payload of the packet
     payload: Box<[u8]>,
+    // defines on how the packet will be delivered.
+    delivery_method: DeliveryMethod,
 }
 
 impl Packet {
-    pub fn new(addr: SocketAddr, payload: Vec<u8>) -> Self {
+    /// Create an new packet by passing the receiver, data and how this packet should be delivered.
+    pub fn new(addr: SocketAddr, payload: Vec<u8>, delivery_method: DeliveryMethod) -> Self {
         Packet {
             addr,
             payload: payload.into_boxed_slice(),
+            delivery_method,
         }
+    }
+
+    /// This will create an unreliable packet.
+    ///
+    /// *Details*
+    ///
+    ///  1. Unreliable
+    ///  2. No guarantee for delivery.
+    ///  3. No guarantee for order.
+    ///  4. No way of getting dropped packet
+    ///  5. Duplication possible
+    ///
+    /// Basically just bare UDP
+    pub fn unreliable(addr: SocketAddr, payload: Vec<u8>) -> Packet {
+        Packet::new(addr,payload,DeliveryMethod::Unreliable)
+    }
+
+    /// This will create an reliable unordered packet.
+    ///
+    /// *Details*
+    ///
+    ///  1. Reliable.
+    ///  2. Guarantee of delivery.
+    ///  3. No guarantee for order.
+    ///  4. Packets will not be dropped.
+    ///  5. Duplication not possible
+    ///
+    /// Basically this is almost TCP like without ordering of packets.
+    pub fn reliable_unordered(addr: SocketAddr, payload: Vec<u8>) -> Packet {
+        Packet::new(addr,payload,DeliveryMethod::ReliableUnordered)
+    }
+
+    /// This will create an reliable unordered packet.
+    ///
+    /// *Details*
+    ///
+    ///  1. Reliable.
+    ///  2. Guarantee of delivery.
+    ///  3. Guarantee for order.
+    ///  4. Packets will not be dropped.
+    ///  5. Duplication not possible
+    ///
+    /// Basically this is almost TCP like with ordering of packets.
+    pub fn reliable_ordered(addr: SocketAddr, payload: Vec<u8>) -> Packet {
+        Packet::new(addr,payload,DeliveryMethod::ReliableOrdered)
+    }
+
+    /// This will create an reliable ordered packet.
+    ///
+    /// *Details*
+    ///
+    ///  1. Unreliable.
+    ///  2. No guarantee of delivery.
+    ///  3. Guarantee for order.
+    ///  4. Packets can be dropped but you will be able to retrieve dropped packets.
+    ///  5. Duplication not possible
+    ///
+    /// Basically this is UDP with the ability to retrieve dropped packets by acknowledgements.
+    pub fn sequenced_ordered(addr: SocketAddr, payload: Vec<u8>) -> Packet {
+        Packet::new(addr,payload,DeliveryMethod::SequencedOrdered)
+    }
+
+    /// This will create an reliable ordered packet.
+    ///
+    /// *Details*
+    ///
+    ///  1. Unreliable.
+    ///  2. No guarantee of delivery.
+    ///  3. No Guarantee for order.
+    ///  4. Packets can be dropped but you will be able to retrieve dropped packets.
+    ///  5. Duplication not possible
+    ///
+    /// Basically this is UDP with the ability to retrieve dropped packets by acknowledgements.
+    pub fn sequenced_unordered(addr: SocketAddr, payload: Vec<u8>) -> Packet {
+        Packet::new(addr,payload,DeliveryMethod::SequencedUnordered)
     }
 
     /// Get the payload (raw data) of this packet.
@@ -25,5 +105,10 @@ impl Packet {
     /// Get the endpoint from this packet.
     pub fn addr(&self) -> SocketAddr {
         self.addr
+    }
+
+    /// Get the type representing on how this packet will be delivered.
+    pub fn delivery_method(&self) -> DeliveryMethod {
+        self.delivery_method
     }
 }

--- a/src/packet/packet_data.rs
+++ b/src/packet/packet_data.rs
@@ -49,10 +49,11 @@ impl PacketData {
 mod tests {
     use super::PacketData;
     use packet::header::PacketHeader;
+    use infrastructure::DeliveryMethod;
 
     #[test]
     fn add_ang_get_parts() {
-        let header = PacketHeader::new(1, 1, 1);
+        let header = PacketHeader::new(1, 1, 1, DeliveryMethod::Unreliable);
 
         let mut packet_data = PacketData::new();
         packet_data.add_fragment(&header, vec![1, 2, 3, 4, 5]);

--- a/src/packet/packet_processor.rs
+++ b/src/packet/packet_processor.rs
@@ -41,7 +41,7 @@ impl PacketProcessor {
         }
 
         return match received_bytes {
-            Ok(Some(payload)) => Ok(Some(Packet::new(addr, payload))),
+            Ok(Some(payload)) => Ok(Some(Packet::sequenced_unordered(addr, payload, ))),
             Ok(None) => Ok(None),
             Err(e) => Err(NetworkError::ReceiveFailed.into()),
         };
@@ -156,6 +156,7 @@ impl PacketProcessor {
 
 mod tests {
     use super::PacketProcessor;
+    use infrastructure::DeliveryMethod;
     use net::{NetworkConfig, SocketState};
     use packet::{header, Packet};
     use std::io::Cursor;
@@ -174,7 +175,7 @@ mod tests {
         let mut test_data: Vec<u8> = vec![1, 2, 3, 4, 5];
 
         // first setup packet data
-        let packet = Packet::new("127.0.0.1:12345".parse().unwrap(), test_data.clone());
+        let packet = Packet::sequenced_unordered("127.0.0.1:12345".parse().unwrap(), test_data.clone());
 
         let mut socket_sate = SocketState::new(&config).unwrap();
         let mut result = socket_sate.pre_process_packet(packet, &config).unwrap();
@@ -205,7 +206,7 @@ mod tests {
         let mut test_data: Vec<u8> = vec![1; 4000];
 
         // first setup packet data
-        let packet = Packet::new("127.0.0.1:12345".parse().unwrap(), test_data.clone());
+        let packet = Packet::sequenced_unordered("127.0.0.1:12345".parse().unwrap(), test_data.clone());
 
         let mut socket_sate = SocketState::new(&config).unwrap();
         let mut result = socket_sate.pre_process_packet(packet, &config).unwrap();

--- a/src/packet/packet_type.rs
+++ b/src/packet/packet_type.rs
@@ -1,0 +1,45 @@
+use packet::header::{PacketHeader, FragmentHeader};
+
+/// These are the different packets that could be send by te user.
+pub enum PacketType
+{
+    /// Packet header containing packet information.
+    Normal(PacketHeader),
+    /// Part of an packet also called 'fragment' containing fragment info.
+    Fragment(FragmentHeader),
+    /// Packet to keep the connection alive.
+    HeartBeat { /* fields ... */ },
+    /// Disconnect request
+    Disconnect { /* fields ... */ }
+}
+
+#[derive(Copy, Clone, Debug, PartialOrd, PartialEq)]
+/// Id to identify an certain packet type.
+pub enum PacketTypeId
+{
+    Packet = 0,
+    Fragment = 1,
+    HeartBeat = 2,
+    Disconnect = 3,
+    Unknown = 255,
+}
+
+impl PacketTypeId
+{
+    /// Get integer value from `PacketTypeId` enum.
+    pub fn get_id(packet_type: PacketTypeId) -> u8
+    {
+        packet_type as u8
+    }
+
+    /// Get `PacketTypeid` enum instance from integer value.
+    pub fn get_packet_type(packet_type_id: u8) -> PacketTypeId {
+        match packet_type_id {
+            0 => PacketTypeId::Packet,
+            1 => PacketTypeId::Fragment,
+            2 => PacketTypeId::HeartBeat,
+            3 => PacketTypeId::Disconnect,
+            _ => PacketTypeId::Unknown
+        }
+    }
+}

--- a/src/packet/raw_packet_data.rs
+++ b/src/packet/raw_packet_data.rs
@@ -29,10 +29,11 @@ mod tests {
     use super::RawPacketData;
     use net::constants::PACKET_HEADER_SIZE;
     use packet::header::PacketHeader;
+    use infrastructure::DeliveryMethod;
 
     #[test]
     fn serialize_raw_data_test() {
-        let header = PacketHeader::new(1, 1, 1);
+        let header = PacketHeader::new(1, 1, 1, DeliveryMethod::SequencedUnordered);
 
         let data = vec![1, 2, 3, 4, 5];
         let mut raw_packet_data = RawPacketData::new(&header, data.clone());

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -97,7 +97,7 @@ impl ServerMoq {
                     Err(_) => {}
                 }
 
-                let send_result = client.send(Packet::new(host, data_to_send.clone()));
+                let send_result = client.send(Packet::sequenced_unordered(host, data_to_send.clone()));
 
                 if len <= config.fragment_size as usize {
                     assert_eq!(


### PR DESCRIPTION
This PR is part of issue #39 and allows having different packet types and is not about processing and interpreting different packets. The next PR I am going to make will be about that as described in #39 

This gist is some  basic draft: https://gist.github.com/TimonPost/303c53fa1454d724120a1173b04a9745


Don't mind if there aren't any comments yet. I forgot to comment some things so that will be added later.

As you can see I have used "sequenced unreliable" packet for now because this is the type we provide now. But later with the next PR this will be dynamic and will be based on packet arrived. 