### PR TITLE
Fix some typo in doc and comments

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -8,7 +8,7 @@ pub type Result<T> = result::Result<T, Error>;
 #[derive(Fail, Debug)]
 pub enum NetworkError {
     // TODO: write more informative error
-    #[fail(display = "Lock posioned")]
+    #[fail(display = "Lock poisoned")]
     AddConnectionToManagerFailed,
     #[fail(display = "TcpStream clone failed")]
     TcpStreamCloneFailed,

--- a/src/net/connection/connection_pool.rs
+++ b/src/net/connection/connection_pool.rs
@@ -16,7 +16,7 @@ pub type ConnectionsCollection = Arc<RwLock<Connections>>;
 // Default time between checks of all clients for timeouts in seconds
 const TIMEOUT_POLL_INTERVAL: u64 = 1;
 
-/// This is an pool of virtual connections (connected) over UDP.
+/// This is a pool of virtual connections (connected) over UDP.
 pub struct ConnectionPool {
     timeout: Duration,
     connections: ConnectionsCollection,
@@ -37,7 +37,7 @@ impl ConnectionPool {
         }
     }
 
-    /// Set the timeout before an client will be seen as disconnected.
+    /// Set disconnect timeout (duration after which a client is seen as disconnected).
     pub fn set_timeout(&mut self, timeout: Duration) {
         self.timeout = timeout;
     }

--- a/src/net/connection/quality.rs
+++ b/src/net/connection/quality.rs
@@ -6,7 +6,7 @@ use net::connection::VirtualConnection;
 use net::NetworkConfig;
 use sequence_buffer::CongestionData;
 
-/// Represents the quality of an network.
+/// Represents the quality of a network.
 pub enum NetworkQuality {
     Good,
     Bad,
@@ -53,7 +53,7 @@ impl NetworkQualityMeasurer {
         }
     }
 
-    /// Converts an duration to milliseconds.
+    /// Converts a duration to milliseconds.
     ///
     /// `as_milliseconds` is not supported yet supported in rust stable.
     /// See this stackoverflow post for more info: https://stackoverflow.com/questions/36816072/how-do-i-get-a-duration-as-a-number-of-milliseconds-in-rust

--- a/src/net/connection/virtual_connection.rs
+++ b/src/net/connection/virtual_connection.rs
@@ -36,7 +36,7 @@ impl VirtualConnection {
         }
     }
 
-    /// Returns a Duration representing since we last heard from the client
+    /// Returns a Duration representing the interval since we last heard from the client
     pub fn last_heard(&self) -> Duration {
         let now = Instant::now();
         now.duration_since(self.last_heard)

--- a/src/net/local_ack.rs
+++ b/src/net/local_ack.rs
@@ -13,17 +13,17 @@ pub struct LocalAckRecord {
 }
 
 impl LocalAckRecord {
-    /// Checks if there are packets in the queue to be aknowleged.
     pub fn is_empty(&mut self) -> bool {
+    /// Checks if there are packets in the queue to be acknowledged.
         self.packets.is_empty()
     }
 
-    /// Gets the total packages in the queue that could be aknowleged.
+    /// Gets the total packages in the queue that could be acknowledged.
     pub fn len(&mut self) -> usize {
         self.packets.len()
     }
 
-    /// Adds a packet to the queue awaiting for an aknowlegement.
+    /// Adds a packet to the queue awaiting for an acknowledgement.
     pub fn enqueue(&mut self, seq: u16, packet: Packet) {
         // TODO: Handle overwriting other packet?
         //   That really shouldn't happen, but it should be encoded here

--- a/src/net/local_ack.rs
+++ b/src/net/local_ack.rs
@@ -13,8 +13,8 @@ pub struct LocalAckRecord {
 }
 
 impl LocalAckRecord {
-    pub fn is_empty(&mut self) -> bool {
     /// Checks if there are packets in the queue to be acknowledged.
+    pub fn is_empty(&self) -> bool {
         self.packets.is_empty()
     }
 

--- a/src/net/network_config.rs
+++ b/src/net/network_config.rs
@@ -3,20 +3,20 @@ use std::default::Default;
 
 #[derive(Clone)]
 pub struct NetworkConfig {
-    /// This is the maximal size an packet can get with all its fragments.
+    /// This is the maximal size a packet can get with all its fragments.
     ///
     /// Recommended value: 16384
     pub max_packet_size: usize,
     /// These are the maximal fragments a packet could be divided into.
     ///
     /// Why can't I have more than 255 (u8)?
-    /// This is because you don't want to send more then 256 fragments over UDP, with high amounts of fragments the change for an invalid packet is very high.
+    /// This is because you don't want to send more then 256 fragments over UDP, with high amounts of fragments the chance for an invalid packet is very high.
     /// Use TCP instead (later we will probably support larger ranges but every fragment packet then needs to be resent if it doesn't get an acknowledgement).
     ///
-    /// Recommended value: 16 but keep in mind to keep this as low as possible.
+    /// Recommended value: 16 but keep in mind that lower is better.
     pub max_fragments: u8,
-    /// This is the size of an fragment.
-    /// If an packet is to large in needs to be spit in fragments.
+    /// This is the size of a fragment.
+    /// If a packet is too large it needs to be split in fragments.
     ///
     /// Recommended value: +- 1450 (1500 is the default MTU)
     pub fragment_size: u16,
@@ -27,9 +27,9 @@ pub struct NetworkConfig {
     /// This is the factor which will smooth out network jitter. So that if one packet is not arrived fast we don't wan't to directly transform to an bad network.
     ///
     /// Recommended value: 10% of the rtt time.
-    /// Value is in percentage where 0 = 0 % and 1 = 100 %
+    /// Value is a ratio (0 = 0% and 1 = 100%)
     pub rtt_smoothing_factor: f32,
-    /// This is the maximal a round trip time (rtt) for packet.
+    /// This is the maximal round trip time (rtt) for packet.
     ///
     /// Recommend value: 250 ms
     /// Value is represented in milliseconds.

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -189,7 +189,7 @@ impl TcpClient {
         };
 
         // We use take here because we can only have one copy of a receiver and we want to the thread to own it
-        // The match is used becaused `std::option::NoneError` is still on nightly
+        // The match is used because `std::option::NoneError` is still on nightly
         let rx = match self.rx.take() {
             Some(rx) => rx,
             None => {

--- a/src/packet/header/fragment.rs
+++ b/src/packet/header/fragment.rs
@@ -6,7 +6,7 @@ use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use std::io::{self, Cursor, Error, ErrorKind, Write};
 
 #[derive(Copy, Clone, Debug)]
-/// This header represents an fragmented packet header.
+/// This header represents a fragmented packet header.
 pub struct FragmentHeader {
     sequence: u16,
     id: u8,
@@ -35,7 +35,7 @@ impl FragmentHeader {
         self.sequence
     }
 
-    /// Get the total number of fragments from an packet this fragment is part of.
+    /// Get the total number of fragments in the packet this fragment is part of.
     pub fn fragment_count(&self) -> u8 {
         self.num_fragments
     }

--- a/src/packet/header/header_reader.rs
+++ b/src/packet/header/header_reader.rs
@@ -3,7 +3,7 @@ use std::io::Cursor;
 pub trait HeaderReader {
     type Header;
 
-    /// Reads the specified header from the given Cursor.
+    /// Read the specified header from the given Cursor.
     fn read(rdr: &mut Cursor<Vec<u8>>) -> Self::Header;
 
     fn size(&self) -> u8;

--- a/src/packet/packet.rs
+++ b/src/packet/packet.rs
@@ -1,9 +1,9 @@
 use std::net::SocketAddr;
 
 #[derive(Clone, PartialEq, Eq, Debug)]
-/// This is a user friendly packet containing the payload from the packet and the enpoint from where it came.
+/// This is a user friendly packet containing the payload from the packet and the endpoint from where it came.
 pub struct Packet {
-    // the address to witch the packet will be send
+    // the endpoint from where it came
     addr: SocketAddr,
     // the raw payload of the packet
     payload: Box<[u8]>,

--- a/src/packet/packet_data.rs
+++ b/src/packet/packet_data.rs
@@ -31,7 +31,7 @@ impl PacketData {
 
     /// Return the total fragments this packet is divided into.
     pub fn fragment_count(&self) -> usize {
-        return self.parts.len();
+        self.parts.len()
     }
 
     /// Return the parts this packet exists of.

--- a/src/packet/packet_data.rs
+++ b/src/packet/packet_data.rs
@@ -3,7 +3,7 @@ use super::RawPacketData;
 
 use std::io::Result;
 
-/// Contains the raw data this packet exists of. Note that an packet can be divided into seperate fragments
+/// Contains the raw data this packet exists of. Note that a packet can be divided into separate fragments
 #[derive(Debug)]
 pub struct PacketData {
     parts: Vec<RawPacketData>,

--- a/src/packet/packet_processor.rs
+++ b/src/packet/packet_processor.rs
@@ -9,7 +9,7 @@ use byteorder::ReadBytesExt;
 
 use error::{NetworkError, Result};
 
-/// An wrapper for processing data.
+/// A wrapper for processing data.
 pub struct PacketProcessor {
     /// buffer for temporarily fragment storage
     reassembly_buffer: SequenceBuffer<ReassemblyData>,
@@ -34,6 +34,7 @@ impl PacketProcessor {
 
         let mut received_bytes = Ok(None);
 
+        // a normal packet starts by a header whose first bit is always 0.
         if prefix_byte & 1 == 0 {
             received_bytes = self.handle_normal_packet(&mut cursor, &addr, socket_state);
         } else {
@@ -103,7 +104,7 @@ impl PacketProcessor {
         return Ok(None);
     }
 
-    /// Extract normal header and dat from data.
+    /// Extract header and data from normal packet.
     fn handle_normal_packet(
         &mut self,
         cursor: &mut Cursor<Vec<u8>>,
@@ -125,7 +126,7 @@ impl PacketProcessor {
         }
     }
 
-    /// if fragment does not exists we need to insert a new entry
+    /// if fragment does not exist we need to insert a new entry
     fn create_fragment_if_not_exists(&mut self, fragment_header: &FragmentHeader) -> Result<()> {
         if !self.reassembly_buffer.exists(fragment_header.sequence()) {
             if fragment_header.id() == 0 {
@@ -161,11 +162,11 @@ mod tests {
     use std::io::Cursor;
     use total_fragments_needed;
 
-    /// Tests if an packet will be processed right.
+    /// Tests if a packet will be processed right.
     ///
     /// 1. first create test Packet
     /// 2. process it with `pre_process_packet` so we have valid raw data
-    /// 3. then assert that the Packet we've gotten from contains the right data.
+    /// 3. then assert that the Packet we've gotten contains the right data.
     #[test]
     fn process_normal_packet_test() {
         let config = NetworkConfig::default();

--- a/src/packet/raw_packet_data.rs
+++ b/src/packet/raw_packet_data.rs
@@ -16,7 +16,7 @@ impl RawPacketData {
         RawPacketData { header, body }
     }
 
-    /// Serialize the packet header and body into on byte buffer
+    /// Serialize the packet header and body into one byte buffer
     pub fn serialize(&mut self) -> Vec<u8> {
         let mut vec = Vec::with_capacity(self.header.len() + self.body.len());
         vec.append(&mut self.header);

--- a/src/sequence_buffer/congestion_data.rs
+++ b/src/sequence_buffer/congestion_data.rs
@@ -1,7 +1,7 @@
 use std::time::Instant;
 
 #[derive(Clone)]
-/// This contains the information needed to know for reassembling fragments.
+/// This contains the information required to reassemble fragments.
 pub struct CongestionData {
     pub sequence: u16,
     pub sending_time: Instant,

--- a/src/sequence_buffer/reassembly_data.rs
+++ b/src/sequence_buffer/reassembly_data.rs
@@ -1,8 +1,7 @@
 use net::constants::{MAX_FRAGMENTS_DEFAULT};
 
-
 #[derive(Clone)]
-/// This contains the information needed to know for reassembling fragments.
+/// This contains the information required to reassemble fragments.
 pub struct ReassemblyData {
     pub sequence: u16,
     pub num_fragments_received: u8,
@@ -29,6 +28,7 @@ impl ReassemblyData {
         }
     }
 }
+
 impl Default for ReassemblyData {
     fn default() -> Self {
         Self {

--- a/src/sequence_buffer/sequence_buffer.rs
+++ b/src/sequence_buffer/sequence_buffer.rs
@@ -1,8 +1,7 @@
 use std::clone::Clone;
 use std::io::Result;
 
-/// Collection for storing data of any kind.
-
+/// Collection to store data of any kind.
 pub struct SequenceBuffer<T>  where T: Default + Clone + Send + Sync  {
     entries: Vec<T>,
     entry_sequences: Vec<u16>,
@@ -10,7 +9,7 @@ pub struct SequenceBuffer<T>  where T: Default + Clone + Send + Sync  {
 }
 
 impl<T> SequenceBuffer<T> where T: Default + Clone + Send + Sync {
-    /// Create collection with an specific capacity.
+    /// Create collection with a specific capacity.
     pub fn with_capacity(size: usize) -> Self {
         let mut entries = Vec::with_capacity(size);
         let mut entry_sequences = Vec::with_capacity(size);
@@ -64,7 +63,7 @@ impl<T> SequenceBuffer<T> where T: Default + Clone + Send + Sync {
         return true;
     }
 
-    /// Get the lenght of the collection.
+    /// Get the length of the collection.
     pub fn len(&self) -> usize {
         self.entries.len()
     }


### PR DESCRIPTION
This fix some typo I came across when reviewing the code base.

This is related to this issue: https://github.com/amethyst/laminar/issues/31

Furthermore, I have some questions:
- Why not `const TIMEOUT_POLL_INTERVAL: Duration = Duration::from_secs(1)`?
    https://github.com/amethyst/laminar/blob/5d89e4fe6e3996a4753afac5d74c6437d0e7f4e7/src/net/connection/connection_pool.rs#L17
- I feel like `packet/header/packet.rs` should be renamed to `packet_header.rs`.
- Is there a reason to not use a thread pool in TcpServer and UdpServer?
