### PR TITLE
Refactor 3: fix easy warnings

### DIFF
--- a/examples/simple_udp.rs
+++ b/examples/simple_udp.rs
@@ -58,7 +58,7 @@ pub fn main() {
         string: String::from("Some information"),
     });
 
-    /// ==== result ====
+    // ==== results ====
     // Moving to lat: 10.555, long: 10.55454, alt: 1.3
     // Moving to lat: 5.4545, long: 3.344, alt: 1.33
     // Received text: "Some information"
@@ -103,7 +103,6 @@ impl Server {
 
         match result {
             Ok(Some(packet)) => {
-                let endpoint: SocketAddr = packet.addr();
                 let received_data: &[u8] = packet.payload();
 
                 // deserialize bytes to `DataType` we passed in with `Client.send()`.

--- a/src/bin/tester.rs
+++ b/src/bin/tester.rs
@@ -10,12 +10,12 @@ fn main() {
     let yaml = load_yaml!("cli.yml");
     let matches = App::from_yaml(yaml).get_matches();
 
-    if let Some(m) = matches.subcommand_matches("server") {
+    if let Some(_) = matches.subcommand_matches("server") {
         run_server();
         exit(0);
     }
 
-    if let Some(m) = matches.subcommand_matches("client") {
+    if let Some(_) = matches.subcommand_matches("client") {
         run_client();
         exit(0);
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,5 @@
 use failure;
-use std::io::{self, ErrorKind};
+use std::io::{ErrorKind};
 use std::result;
 
 pub type Error = failure::Error;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,5 @@
 use failure;
-use std::io::{ErrorKind};
+use std::io::ErrorKind;
 use std::result;
 
 pub type Error = failure::Error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,6 @@ extern crate byteorder;
 extern crate failure;
 extern crate serde;
 #[macro_use]
-extern crate serde_derive;
-#[macro_use]
 extern crate log;
 #[macro_use]
 extern crate failure_derive;

--- a/src/net/connection/connection_pool.rs
+++ b/src/net/connection/connection_pool.rs
@@ -56,7 +56,7 @@ impl ConnectionPool {
         Ok(connection.clone())
     }
 
-    /// Start loop that will detect if connections will are disconnected.
+    /// Start loop that detect connection timeouts.
     ///
     /// This function starts a background thread that does the following:
     /// 1. Gets a read lock on the HashMap containing all the connections
@@ -78,8 +78,8 @@ impl ConnectionPool {
                     Ok(lock) => {
                         ConnectionPool::check_for_timeouts(&*lock, poll_interval, &sender);
                     }
-                    Err(_) => {
-                        error!("Unable to acquire read lock to check for timed out connections")
+                    Err(e) => {
+                        panic!("Error when checking for timed out connections: {}", e)
                     }
                 }
                 thread::sleep(poll_interval);

--- a/src/net/connection/connection_pool.rs
+++ b/src/net/connection/connection_pool.rs
@@ -78,7 +78,7 @@ impl ConnectionPool {
                     Ok(lock) => {
                         ConnectionPool::check_for_timeouts(&*lock, poll_interval, &sender);
                     }
-                    Err(e) => {
+                    Err(_) => {
                         error!("Unable to acquire read lock to check for timed out connections")
                     }
                 }

--- a/src/net/connection/connection_pool.rs
+++ b/src/net/connection/connection_pool.rs
@@ -56,7 +56,7 @@ impl ConnectionPool {
         Ok(connection.clone())
     }
 
-    /// Start loop that detect connection timeouts.
+    /// Start loop that detects when a connection has timed out.
     ///
     /// This function starts a background thread that does the following:
     /// 1. Gets a read lock on the HashMap containing all the connections

--- a/src/net/connection/quality.rs
+++ b/src/net/connection/quality.rs
@@ -30,11 +30,10 @@ impl NetworkQualityMeasurer {
         connection: &mut RwLockWriteGuard<VirtualConnection>,
         ack_seq: u16,
     ) {
-        let mut smoothed_rrt = 0.0;
-        {
-            let mut congestion_data = connection.congestion_avoidance_buffer.get_mut(ack_seq);
-            smoothed_rrt = self.get_smoothed_rtt(congestion_data);
-        }
+        let smoothed_rrt = {
+            let congestion_data = connection.congestion_avoidance_buffer.get_mut(ack_seq);
+            self.get_smoothed_rtt(congestion_data)
+        };
 
         connection.rtt = smoothed_rrt;
     }
@@ -80,11 +79,9 @@ impl NetworkQualityMeasurer {
 mod test {
     use net::connection::{VirtualConnection};
     use net::NetworkConfig;
-    use sequence_buffer::CongestionData;
-    use super::{NetworkQualityMeasurer, RwLockWriteGuard};
+    use super::NetworkQualityMeasurer;
     use std::net::ToSocketAddrs;
-    use std::time::{Duration, Instant};
-    use std::sync::RwLock;
+    use std::time::Duration;
 
     static TEST_HOST_IP: &'static str = "127.0.0.1";
     static TEST_BAD_HOST_IP: &'static str = "800.0.0.1";

--- a/src/net/local_ack.rs
+++ b/src/net/local_ack.rs
@@ -63,7 +63,7 @@ impl LocalAckRecord {
 
 #[cfg(test)]
 mod test {
-    use super::super::{ExternalAcks, LocalAckRecord};
+    use super::super::LocalAckRecord;
     use super::Packet;
     use std::net::{IpAddr, SocketAddr};
     use std::str::FromStr;

--- a/src/net/socket_state.rs
+++ b/src/net/socket_state.rs
@@ -57,9 +57,9 @@ impl SocketState {
 
         let connection = self.connections.get_connection_or_insert(&packet.addr())?;
 
-        let mut connection_seq: u16 = 0;
-        let mut their_last_seq: u16 = 0;
-        let mut their_ack_field: u32 = 0;
+        let connection_seq: u16;
+        let their_last_seq: u16;
+        let their_ack_field: u32;
 
         {
             let mut lock = connection
@@ -178,14 +178,13 @@ impl SocketState {
 
 #[cfg(test)]
 mod test {
-    use net::{constants, NetworkConfig, SocketState, VirtualConnection};
+    use net::{constants, NetworkConfig, SocketState};
     use packet::header::{FragmentHeader, HeaderReader, PacketHeader};
     use packet::{Packet, PacketData};
 
     use std::io::Cursor;
-    use std::net::{IpAddr, SocketAddr, ToSocketAddrs};
+    use std::net::{IpAddr, SocketAddr};
     use std::str::FromStr;
-    use std::{thread, time};
 
     use total_fragments_needed;
 
@@ -197,7 +196,7 @@ mod test {
         let config = NetworkConfig::default();
 
         // - 1 so that packet can fit inside one fragment.
-        let mut data = vec![0; config.fragment_size as usize - 1];
+        let data = vec![0; config.fragment_size as usize - 1];
 
         // do some test processing of the data.
         let mut processed_packet: (SocketAddr, PacketData) =

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -221,12 +221,11 @@ impl TcpClient {
 #[cfg(test)]
 mod test {
     use super::*;
-    use std::sync::{Arc, Mutex};
     use std::thread;
 
     #[test]
     fn test_create_tcp_socket_state() {
-        let test_state = TcpSocketState::new();
+        let _test_state = TcpSocketState::new();
     }
 
     #[test]

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -50,7 +50,7 @@ impl UdpSocket {
     }
 
     /// Sends data on the socket to the given address. On success, returns the number of bytes written.
-    pub fn send(&mut self, mut packet: Packet) -> Result<usize> {
+    pub fn send(&mut self, packet: Packet) -> Result<usize> {
         let (addr, mut packet_data) = self.state.pre_process_packet(packet, &self.config)?;
 
         let mut bytes_sent = 0;

--- a/src/packet/header/fragment.rs
+++ b/src/packet/header/fragment.rs
@@ -116,8 +116,8 @@ impl HeaderReader for FragmentHeader {
     }
 }
 
+#[cfg(test)]
 mod tests {
-    use byteorder::ReadBytesExt;
     use packet::header::{FragmentHeader, HeaderParser, HeaderReader, PacketHeader};
     use infrastructure::DeliveryMethod;
     use std::io::Cursor;
@@ -125,7 +125,7 @@ mod tests {
     #[test]
     pub fn serializes_deserialize_fragment_header_test() {
         let packet_header = PacketHeader::new(1, 1, 5421, DeliveryMethod::Unreliable);
-        let packet_serialized: Vec<u8> = packet_header.parse().unwrap();
+        let _packet_serialized: Vec<u8> = packet_header.parse().unwrap();
 
         let fragment = FragmentHeader::new(0, 1, packet_header.clone());
         let fragment_serialized = fragment.parse().unwrap();

--- a/src/packet/header/heart_beat.rs
+++ b/src/packet/header/heart_beat.rs
@@ -1,9 +1,8 @@
-use super::PacketHeader;
 use super::{HeaderParser, HeaderReader};
-use net::constants::{FRAGMENT_HEADER_SIZE, HEART_BEAT_HEADER_SIZE};
+use net::constants::{HEART_BEAT_HEADER_SIZE};
 use packet::PacketTypeId;
-use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
-use std::io::{self, Cursor, Error, ErrorKind, Write};
+use byteorder::{ReadBytesExt, WriteBytesExt};
+use std::io::{self, Cursor, Error, ErrorKind};
 
 #[derive(Copy, Clone, Debug)]
 /// This header represents an heartbeat packet header.
@@ -42,7 +41,7 @@ impl HeaderReader for HeartBeatHeader {
             return Err(Error::new(ErrorKind::Other, "Invalid fragment header"));
         }
 
-        let mut header = HeartBeatHeader {
+        let header = HeartBeatHeader {
            packet_type_id
         };
 

--- a/src/packet/header/packet.rs
+++ b/src/packet/header/packet.rs
@@ -94,9 +94,9 @@ impl HeaderReader for PacketHeader {
     }
 }
 
+#[cfg(test)]
 mod tests {
-    use byteorder::ReadBytesExt;
-    use packet::header::{FragmentHeader, HeaderParser, HeaderReader, PacketHeader};
+    use packet::header::{HeaderParser, HeaderReader, PacketHeader};
     use infrastructure::DeliveryMethod;
     use std::io::Cursor;
 
@@ -106,7 +106,7 @@ mod tests {
         let packet_serialized: Vec<u8> = packet_header.parse().unwrap();
 
         let mut cursor = Cursor::new(packet_serialized);
-        let packet_deserialized: PacketHeader = PacketHeader::read(&mut cursor).unwrap();
+        let _packet_deserialized: PacketHeader = PacketHeader::read(&mut cursor).unwrap();
 
         assert_eq!(packet_header.seq, 1);
         assert_eq!(packet_header.ack_seq, 1);

--- a/src/packet/packet_data.rs
+++ b/src/packet/packet_data.rs
@@ -46,6 +46,7 @@ impl PacketData {
     }
 }
 
+#[cfg(test)]
 mod tests {
     use super::PacketData;
     use packet::header::PacketHeader;
@@ -62,7 +63,7 @@ mod tests {
 
         assert_eq!(packet_data.fragment_count(), 3);
 
-        packet_data.parts().into_iter().map(|x| {
+        let _ = packet_data.parts().into_iter().map(|x| {
             assert_eq!(x, vec![1, 2, 3, 4, 5]);
         });
     }

--- a/src/packet/packet_processor.rs
+++ b/src/packet/packet_processor.rs
@@ -1,11 +1,10 @@
-use std::io::{self, Cursor, Error, ErrorKind, Read, Write};
+use std::io::{Cursor, Read, Write};
 use std::net::SocketAddr;
 
 use net::{SocketState, NetworkConfig};
 use packet::{header, Packet};
-use sequence_buffer::{SequenceBuffer, ReassemblyData, CongestionData};
-use self::header::{FragmentHeader, PacketHeader, HeaderParser, HeaderReader};
-use byteorder::ReadBytesExt;
+use sequence_buffer::{SequenceBuffer, ReassemblyData};
+use self::header::{FragmentHeader, PacketHeader, HeaderReader};
 
 use error::{NetworkError, Result};
 
@@ -32,19 +31,17 @@ impl PacketProcessor {
         let prefix_byte = packet[0];
         let mut cursor = Cursor::new(packet);
 
-        let mut received_bytes = Ok(None);
-
-        // a normal packet starts by a header whose first bit is always 0.
-        if prefix_byte & 1 == 0 {
-            received_bytes = self.handle_normal_packet(&mut cursor, &addr, socket_state);
+        let received_bytes = if prefix_byte & 1 == 0 {
+            // a normal packet starts by a header whose first bit is always 0.
+            self.handle_normal_packet(&mut cursor, &addr, socket_state)
         } else {
-            received_bytes = self.handle_fragment(&mut cursor);
-        }
+            self.handle_fragment(&mut cursor)
+        };
 
         return match received_bytes {
             Ok(Some(payload)) => Ok(Some(Packet::sequenced_unordered(addr, payload, ))),
             Ok(None) => Ok(None),
-            Err(e) => Err(NetworkError::ReceiveFailed.into()),
+            Err(_) => Err(NetworkError::ReceiveFailed.into()),
         };
     }
 
@@ -55,10 +52,10 @@ impl PacketProcessor {
 
         self.create_fragment_if_not_exists(&fragment_header);
 
-        let mut num_fragments_received = 0;
-        let mut num_fragments_total = 0;
-        let mut sequence = 0;
-        let mut total_buffer = Vec::new();
+        let num_fragments_received;
+        let num_fragments_total;
+        let sequence;
+        let total_buffer;
 
         {
             // get entry of previous received fragments
@@ -122,7 +119,7 @@ impl PacketProcessor {
 
                 Ok(Some(payload))
             }
-            Err(e) => Err(NetworkError::HeaderParsingFailed.into()),
+            Err(_) => Err(NetworkError::HeaderParsingFailed.into()),
         }
     }
 
@@ -155,12 +152,11 @@ impl PacketProcessor {
     }
 }
 
+#[cfg(test)]
 mod tests {
     use super::PacketProcessor;
-    use infrastructure::DeliveryMethod;
     use net::{NetworkConfig, SocketState};
-    use packet::{header, Packet};
-    use std::io::Cursor;
+    use packet::{Packet};
     use total_fragments_needed;
 
     /// Tests if a packet will be processed right.
@@ -173,7 +169,7 @@ mod tests {
         let config = NetworkConfig::default();
         let mut packet_processor = PacketProcessor::new(&config);
 
-        let mut test_data: Vec<u8> = vec![1, 2, 3, 4, 5];
+        let test_data: Vec<u8> = vec![1, 2, 3, 4, 5];
 
         // first setup packet data
         let packet = Packet::sequenced_unordered("127.0.0.1:12345".parse().unwrap(), test_data.clone());
@@ -181,7 +177,7 @@ mod tests {
         let mut socket_sate = SocketState::new(&config).unwrap();
         let mut result = socket_sate.pre_process_packet(packet, &config).unwrap();
 
-        let mut packet_data = result.1.parts();
+        let packet_data = result.1.parts();
 
         assert_eq!(packet_data.len(), 1);
 
@@ -204,7 +200,7 @@ mod tests {
         let config = NetworkConfig::default();
         let mut packet_processor = PacketProcessor::new(&config);
 
-        let mut test_data: Vec<u8> = vec![1; 4000];
+        let test_data: Vec<u8> = vec![1; 4000];
 
         // first setup packet data
         let packet = Packet::sequenced_unordered("127.0.0.1:12345".parse().unwrap(), test_data.clone());
@@ -212,7 +208,7 @@ mod tests {
         let mut socket_sate = SocketState::new(&config).unwrap();
         let mut result = socket_sate.pre_process_packet(packet, &config).unwrap();
 
-        let mut packet_data = result.1.parts();
+        let packet_data = result.1.parts();
 
         let expected_fragments =
             total_fragments_needed(test_data.len() as u16, config.fragment_size) as usize;

--- a/src/packet/packet_processor.rs
+++ b/src/packet/packet_processor.rs
@@ -156,7 +156,7 @@ impl PacketProcessor {
 mod tests {
     use super::PacketProcessor;
     use net::{NetworkConfig, SocketState};
-    use packet::{Packet};
+    use packet::Packet;
     use total_fragments_needed;
 
     /// Tests if a packet will be processed right.

--- a/src/packet/raw_packet_data.rs
+++ b/src/packet/raw_packet_data.rs
@@ -25,6 +25,7 @@ impl RawPacketData {
     }
 }
 
+#[cfg(test)]
 mod tests {
     use super::RawPacketData;
     use net::constants::PACKET_HEADER_SIZE;

--- a/src/sequence_buffer/sequence_buffer.rs
+++ b/src/sequence_buffer/sequence_buffer.rs
@@ -1,11 +1,9 @@
 use std::clone::Clone;
-use std::io::Result;
 
 /// Collection to store data of any kind.
 pub struct SequenceBuffer<T>  where T: Default + Clone + Send + Sync  {
     entries: Vec<T>,
     entry_sequences: Vec<u16>,
-    size: usize,
 }
 
 impl<T> SequenceBuffer<T> where T: Default + Clone + Send + Sync {
@@ -15,10 +13,9 @@ impl<T> SequenceBuffer<T> where T: Default + Clone + Send + Sync {
         let mut entry_sequences = Vec::with_capacity(size);
 
         entries.resize(size, T::default());
-        entry_sequences.resize(size, 0xFFFF_FFFF);
+        entry_sequences.resize(size, 0xFFFF);
 
         SequenceBuffer {
-            size,
             entries,
             entry_sequences,
         }
@@ -36,13 +33,13 @@ impl<T> SequenceBuffer<T> where T: Default + Clone + Send + Sync {
     }
 
     /// Insert new entry into the collection.
-    pub fn insert(&mut self, data: T, sequence: u16) -> Result<&mut T> {
+    pub fn insert(&mut self, data: T, sequence: u16) -> &mut T {
         let index = self.index(sequence);
 
         self.entries[index] = data;
         self.entry_sequences[index] = sequence;
 
-        Ok(&mut self.entries[index])
+        &mut self.entries[index]
     }
 
     /// Remove entry from collection.
@@ -50,7 +47,7 @@ impl<T> SequenceBuffer<T> where T: Default + Clone + Send + Sync {
         // TODO: validity check
         let index = self.index(sequence);
         self.entries[index] = T::default();
-        self.entry_sequences[index] = 0xFFFF_FFFF;
+        self.entry_sequences[index] = 0xFFFF;
     }
 
     /// checks if an certain entry exists.
@@ -74,6 +71,7 @@ impl<T> SequenceBuffer<T> where T: Default + Clone + Send + Sync {
     }
 }
 
+#[cfg(test)]
 mod tests {
     use super::SequenceBuffer;
 

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -2,7 +2,7 @@ extern crate laminar;
 
 use laminar::net::{constants, NetworkConfig, SocketAddr, UdpSocket};
 use laminar::packet::Packet;
-use std::sync::mpsc::{channel, Receiver, Sender};
+use std::sync::mpsc::Receiver;
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
@@ -32,7 +32,6 @@ impl ServerMoq {
         let mut udp_socket: UdpSocket = UdpSocket::bind(self.host, self.config.clone()).unwrap();
         udp_socket.set_nonblocking(self.non_blocking);
 
-        let mut packets_total_received = 0;
         let mut packet_throughput = 0;
         let mut packets_total_received = 0;
         let mut second_counter = Instant::now();
@@ -85,7 +84,7 @@ impl ServerMoq {
 
             let len = data_to_send.len();
 
-            for i in 0..packets_to_send {
+            for _ in 0..packets_to_send {
                 let result = client.recv();
 
                 match result {

--- a/tests/fragments.rs
+++ b/tests/fragments.rs
@@ -3,10 +3,9 @@ extern crate laminar;
 mod common;
 
 use std::sync::mpsc;
-use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
 
-use laminar::net::{NetworkConfig, SocketAddr};
+use laminar::net::NetworkConfig;
 
 use common::{ClientStub, ServerMoq};
 

--- a/tests/multiple_clients.rs
+++ b/tests/multiple_clients.rs
@@ -3,10 +3,9 @@ extern crate laminar;
 mod common;
 
 use std::sync::mpsc;
-use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
 
-use laminar::net::{NetworkConfig, SocketAddr};
+use laminar::net::NetworkConfig;
 
 use common::{ClientStub, ServerMoq};
 

--- a/tests/normal.rs
+++ b/tests/normal.rs
@@ -3,10 +3,9 @@ extern crate laminar;
 mod common;
 
 use std::sync::mpsc;
-use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
 
-use laminar::net::{NetworkConfig, SocketAddr};
+use laminar::net::NetworkConfig;
 
 use common::{ClientStub, ServerMoq};
 


### PR DESCRIPTION
Related to https://github.com/amethyst/laminar/issues/31

I fixed most easy warnings:
- unused import
- unused value
- useless mut
- some unused variables

I also fixed the overflowing_literals warnings, you might want to have a closer look at `sequence_buffer.rs` file diff.

Also, there were missing `#[cfg(test)]` causing unused import warnings when not building tests.

I didn't fix warnings related to Error handling because these may require special attention.

Also there are some unused parameters and unused struct attributes that I believe will be used in the future.

Some remarks:
- Purpose of this attribute is not documented + the attribute itself is never used.
 https://github.com/amethyst/laminar/blob/master/src/net/connection/connection_pool.rs#L23
- These are arbitrarily hardcoded values.
 https://github.com/amethyst/laminar/blob/master/src/net/connection/connection_pool.rs#L29
 https://github.com/amethyst/laminar/blob/master/src/net/connection/connection_pool.rs#L33
 Shall I create constants for them?
- This is unused private method
 https://github.com/amethyst/laminar/blob/master/src/net/socket_state.rs#L174
 Shall we delete it or make it public?

There is a lot of dead code. This is not a good practice (related to https://github.com/amethyst/laminar/issues/45 )