### PR TITLE
Implemented protocol id for headers.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,8 @@ failure = "0.1"
 failure_derive = "0.1"
 clap = { version = "2.32", features = ["yaml"], optional = true }
 env_logger = { version = "0.5.13", optional = true }
+crc = "1.8"
+lazy_static = "1.1.0"
 
 [dev-dependencies]
 criterion = "0.2"

--- a/src/error/network_error.rs
+++ b/src/error/network_error.rs
@@ -25,6 +25,8 @@ pub enum NetworkErrorKind
     UDPSocketStateCreationFailed,
     #[fail(display = "The received data did not have any length.")]
     ReceivedDataToShort,
+    #[fail(display = "The protocol versions do not match.")]
+    ProtocolVersionMismatch,
 }
 
 #[derive(Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,11 +8,15 @@ extern crate serde;
 extern crate log;
 #[macro_use]
 extern crate failure_derive;
+extern crate crc;
+#[macro_use]
+extern crate lazy_static;
 
 pub mod error;
 pub mod events;
 pub mod net;
 pub mod packet;
+pub mod protocol_version;
 mod sequence_buffer;
 pub mod infrastructure;
 

--- a/src/net/constants.rs
+++ b/src/net/constants.rs
@@ -1,7 +1,6 @@
-pub const FRAGMENT_HEADER_SIZE: u8 = 5;
-pub const PACKET_HEADER_SIZE: u8 = 10;
-pub const HEART_BEAT_HEADER_SIZE: u8 = 1;
-
+pub const FRAGMENT_HEADER_SIZE: u8 = 9;
+pub const PACKET_HEADER_SIZE: u8 = 14;
+pub const HEART_BEAT_HEADER_SIZE: u8 = 5;
 pub const MAX_FRAGMENTS_DEFAULT: u16 = 16;
 pub const FRAGMENT_SIZE_DEFAULT: u16 = 1024;
 /// Maximum transmission unit of the payload.
@@ -12,3 +11,9 @@ pub const FRAGMENT_SIZE_DEFAULT: u16 = 1024;
 /// This is not strictly guaranteed -- there may be less room in an ethernet frame than this due to
 /// variability in ipv6 header size.
 pub const DEFAULT_MTU: u16 = 1452;
+/// This is the current protocol version.
+///
+/// It is used for:
+/// - Generating crc32 for the packet header.
+/// - Validating if arriving packets have the same protocol version.
+pub const PROTOCOL_VERSION: &'static str = "laminar-0.1.0";

--- a/src/protocol_version.rs
+++ b/src/protocol_version.rs
@@ -1,0 +1,34 @@
+use std::hash::Hasher;
+use std::sync::Mutex;
+
+use crc::Hasher32;
+use crc::crc32;
+
+pub use net::constants::PROTOCOL_VERSION;
+
+lazy_static! {
+    // The CRC32 of the current protocol version.
+    static ref VERSION_CRC32: Mutex<u32> = Mutex::new(crc32::checksum_ieee(PROTOCOL_VERSION.as_bytes()));
+}
+
+/// Wrapper to provide some functions to perform with the current protocol version.
+pub struct ProtocolVersion;
+
+impl ProtocolVersion
+{
+    /// Get the current protocol version.
+    pub fn get_version() -> &'static str
+    {
+        return PROTOCOL_VERSION
+    }
+
+    /// This will return the crc32 from the current protocol version.
+    pub fn get_crc32() -> u32 {
+        VERSION_CRC32.lock().unwrap().clone()
+    }
+
+    /// Validate a crc32 with the current protocol version and return the results.
+    pub fn valid_version(protocol_version_crc32: u32) -> bool {
+        protocol_version_crc32 == VERSION_CRC32.lock().unwrap().clone()
+    }
+}


### PR DESCRIPTION
Implemented protocol id see #4  for more information.

Please during review check these out:
- laminar-0.1.0 
From this value or crc32 will be generated do we agree on this notation for protocol version.
- I use unsafe in on place see /src/protocol_version.rs, I can change this to `lazy_static` but like the current way, it could also be done. What should I do with this? 
- I use CRC32 for encoding of protocol version. Maybe an option to have CRC16? I don't know if there is some major difference between the who other than the size.

O shit. I see that I have to comment some things from `ProtocolVersion` I'll update it later.