### PR TITLE
Fix warnings produced by unused code

### DIFF
--- a/examples/udp.rs
+++ b/examples/udp.rs
@@ -32,7 +32,7 @@ pub fn send_data() {
     let packet = construct_packet();
 
     // next send or packet to the endpoint we earlier putted into the packet.
-    udp_socket.send(packet);
+    udp_socket.send(packet).unwrap();
 }
 
 /// This is an example of how to receive data over udp on an specific socket address with blocking the current thread.
@@ -44,7 +44,7 @@ pub fn receive_data_with_blocking() {
     let mut udp_socket: UdpSocket = UdpSocket::bind(server_address(), config).unwrap();
 
     // next we could specify if or socket should block the current thread when receiving data or not (default = false)
-    udp_socket.set_nonblocking(false);
+    udp_socket.set_nonblocking(false).unwrap();
 
     // Next start receiving.
     let result = udp_socket.recv();
@@ -80,7 +80,7 @@ pub fn receive_data_without_blocking() {
     let mut udp_socket: UdpSocket = UdpSocket::bind(client_address(), config).unwrap();
 
     // next we could specify if or socket should block the current thread when receiving data or not (default = false)
-    udp_socket.set_nonblocking(false);
+    udp_socket.set_nonblocking(false).unwrap();
 
     // setup a thread to do the receiving
     // Next start receiving.

--- a/src/error/error_kinds.rs
+++ b/src/error/error_kinds.rs
@@ -1,18 +1,15 @@
-use std::io;
-
 /// Errors that could occur with constructing parsing packet contents
 #[derive(Fail, Debug, PartialEq, Eq, Clone)]
 pub enum PacketErrorKind {
     #[fail(display = "The packet size was bigger than the max allowed size.")]
     ExceededMaxPacketSize,
     #[fail(display = "The packet has a wrong id.")]
-    PacketHasWrongId
+    PacketHasWrongId,
 }
 
 /// Errors that could occur with constructing/parsing fragment contents
 #[derive(Fail, Debug, PartialEq, Eq, Clone)]
-pub enum FragmentErrorKind
-{
+pub enum FragmentErrorKind {
     #[fail(display = "Packet header was attached to fragment.")]
     PacketHeaderNotFound,
     #[fail(display = "Entry already exists in the buffer.")]
@@ -26,5 +23,5 @@ pub enum FragmentErrorKind
     #[fail(display = "The fragment has a wrong id.")]
     FragmentHasWrongId,
     #[fail(display = "The fragment supposed to be in a cache but it was not found.")]
-    CouldNotFindFragmentById
+    CouldNotFindFragmentById,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,11 +14,11 @@ extern crate lazy_static;
 
 pub mod error;
 pub mod events;
+pub mod infrastructure;
 pub mod net;
 pub mod packet;
 pub mod protocol_version;
 mod sequence_buffer;
-pub mod infrastructure;
 
 /// This functions checks how many times a number fits into another number and will round up.
 ///
@@ -50,6 +50,10 @@ pub mod infrastructure;
 /// So for 4000 bytes we need 4 fragments
 /// [fragment: 1024] [fragment: 1024] [fragment: 1024] [fragment: 928]
 fn total_fragments_needed(payload_length: u16, fragment_size: u16) -> u16 {
-    let remainder = if payload_length % fragment_size > 0 { 1 } else { 0 };
+    let remainder = if payload_length % fragment_size > 0 {
+        1
+    } else {
+        0
+    };
     ((payload_length / fragment_size) + remainder)
 }

--- a/src/net/socket_state.rs
+++ b/src/net/socket_state.rs
@@ -1,15 +1,15 @@
+use std::error::Error;
 use std::sync::mpsc::{self, Receiver, Sender};
 use std::thread;
-use std::time::{Duration, Instant};
-use std::error::Error;
+use std::time::Instant;
 
+use error::{FragmentErrorKind, NetworkError, NetworkResult, PacketErrorKind};
+use events::Event;
+use net::connection::{ConnectionPool, NetworkQualityMeasurer};
+use net::{NetworkConfig, SocketAddr};
+use packet::header::{FragmentHeader, PacketHeader};
 use packet::{Packet, PacketData};
 use sequence_buffer::CongestionData;
-use packet::header::{FragmentHeader, PacketHeader};
-use net::{SocketAddr, NetworkConfig};
-use net::connection::{ConnectionPool,NetworkQualityMeasurer};
-use error::{NetworkError, NetworkResult, PacketErrorKind, FragmentErrorKind};
-use events::Event;
 use total_fragments_needed;
 
 /// This type handles the UDP-socket state.
@@ -85,7 +85,12 @@ impl SocketState {
 
         let mut packet_data = PacketData::new();
 
-        let packet_header = PacketHeader::new(connection_seq, their_last_seq, their_ack_field, packet.delivery_method());
+        let packet_header = PacketHeader::new(
+            connection_seq,
+            their_last_seq,
+            their_ack_field,
+            packet.delivery_method(),
+        );
 
         let payload = packet.payload();
         let payload_length = payload.len() as u16; /* safe cast because max packet size is u16 */
@@ -123,7 +128,7 @@ impl SocketState {
 
         let mut lock = connection
             .write()
-            .map_err(|error|  NetworkError::poisoned_connection_error(error.description()))?;
+            .map_err(|error| NetworkError::poisoned_connection_error(error.description()))?;
 
         // each time we send a packet we increase the local sequence number
         lock.seq_num = lock.seq_num.wrapping_add(1);
@@ -137,18 +142,22 @@ impl SocketState {
 
         let mut lock = connection
             .write()
-            .map_err(|error|  NetworkError::poisoned_connection_error(error.description()))?;
+            .map_err(|error| NetworkError::poisoned_connection_error(error.description()))?;
 
         let packets = lock.dropped_packets.drain(..).collect();
         Ok(packets)
     }
 
     /// This will process an incoming packet and update acknowledgement information.
-    pub fn process_received(&mut self, addr: SocketAddr, packet: &PacketHeader) -> NetworkResult<()> {
+    pub fn process_received(
+        &mut self,
+        addr: SocketAddr,
+        packet: &PacketHeader,
+    ) -> NetworkResult<()> {
         let connection = self.connections.get_connection_or_insert(&addr)?;
         let mut lock = connection
             .write()
-            .map_err(|error|  NetworkError::poisoned_connection_error(error.description()))?;
+            .map_err(|error| NetworkError::poisoned_connection_error(error.description()))?;
 
         lock.their_acks.ack(packet.seq);
         lock.last_heard = Instant::now();
@@ -173,9 +182,9 @@ impl SocketState {
         rx.try_iter().collect()
     }
 
-    // Wrapper around getting the events sender
-    // This will cause a clone to be done, but this is low cost
-    fn get_events_sender(&self) -> Sender<Event> {
+    /// Wrapper around getting the events sender
+    /// This will cause a clone to be done, but this is low cost
+    pub fn get_events_sender(&self) -> Sender<Event> {
         self.events.0.clone()
     }
 }
@@ -191,9 +200,6 @@ mod test {
     use std::str::FromStr;
 
     use total_fragments_needed;
-
-    static TEST_HOST_IP: &'static str = "127.0.0.1";
-    static TEST_PORT: &'static str = "20000";
 
     #[test]
     pub fn construct_packet_less_than_mtu() {

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -1,12 +1,9 @@
 use std::net::{self, ToSocketAddrs};
 
-use error::{NetworkResult, NetworkError, NetworkErrorKind};
+use error::{NetworkError, NetworkErrorKind, NetworkResult};
 use events::Event;
 use net::{NetworkConfig, SocketState};
 use packet::{Packet, PacketProcessor};
-
-/// Maximum amount of data that we can read from a datagram
-const BUFFER_SIZE: usize = 1024;
 
 /// Represents an <ip>:<port> combination listening for UDP traffic
 pub struct UdpSocket {

--- a/src/packet/header/heart_beat_header.rs
+++ b/src/packet/header/heart_beat_header.rs
@@ -1,23 +1,23 @@
 use super::{HeaderParser, HeaderReader};
+use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
+use error::NetworkResult;
 use net::constants::HEART_BEAT_HEADER_SIZE;
 use packet::PacketTypeId;
-use byteorder::{ReadBytesExt, WriteBytesExt,BigEndian};
-use std::io::Cursor;
-use error::{NetworkResult, PacketErrorKind};
 use protocol_version::ProtocolVersion;
+use std::io::Cursor;
 
 #[derive(Copy, Clone, Debug)]
 /// This header represents an heartbeat packet header.
 /// An heart beat just keeps the client awake.
 pub struct HeartBeatHeader {
-    packet_type_id: PacketTypeId
+    packet_type_id: PacketTypeId,
 }
 
 impl HeartBeatHeader {
     /// Create new heartbeat header.
     pub fn new() -> Self {
         HeartBeatHeader {
-            packet_type_id: PacketTypeId::HeartBeat
+            packet_type_id: PacketTypeId::HeartBeat,
         }
     }
 }
@@ -27,7 +27,7 @@ impl HeaderParser for HeartBeatHeader {
 
     fn parse(&self) -> <Self as HeaderParser>::Output {
         let mut wtr = Vec::new();
-        wtr.write_u32::<BigEndian>(ProtocolVersion::get_crc32());
+        wtr.write_u32::<BigEndian>(ProtocolVersion::get_crc32())?;
         wtr.write_u8(PacketTypeId::get_id(self.packet_type_id))?;
 
         Ok(wtr)
@@ -41,7 +41,7 @@ impl HeaderReader for HeartBeatHeader {
         let _ = rdr.read_u32::<BigEndian>()?;
         let _ = rdr.read_u8();
         let header = HeartBeatHeader {
-           packet_type_id: PacketTypeId::HeartBeat
+            packet_type_id: PacketTypeId::HeartBeat,
         };
 
         Ok(header)
@@ -49,8 +49,6 @@ impl HeaderReader for HeartBeatHeader {
 
     /// Get the size of this header.
     fn size(&self) -> u8 {
-       return HEART_BEAT_HEADER_SIZE;
+        return HEART_BEAT_HEADER_SIZE;
     }
 }
-
-

--- a/src/protocol_version.rs
+++ b/src/protocol_version.rs
@@ -1,7 +1,5 @@
-use std::hash::Hasher;
 use std::sync::Mutex;
 
-use crc::Hasher32;
 use crc::crc32;
 
 pub use net::constants::PROTOCOL_VERSION;
@@ -14,12 +12,10 @@ lazy_static! {
 /// Wrapper to provide some functions to perform with the current protocol version.
 pub struct ProtocolVersion;
 
-impl ProtocolVersion
-{
+impl ProtocolVersion {
     /// Get the current protocol version.
-    pub fn get_version() -> &'static str
-    {
-        return PROTOCOL_VERSION
+    pub fn get_version() -> &'static str {
+        return PROTOCOL_VERSION;
     }
 
     /// This will return the crc32 from the current protocol version.

--- a/src/sequence_buffer/reassembly_data.rs
+++ b/src/sequence_buffer/reassembly_data.rs
@@ -1,4 +1,4 @@
-use net::constants::{MAX_FRAGMENTS_DEFAULT};
+use net::constants::MAX_FRAGMENTS_DEFAULT;
 
 #[derive(Clone)]
 /// This contains the information required to reassemble fragments.
@@ -7,18 +7,11 @@ pub struct ReassemblyData {
     pub num_fragments_received: u8,
     pub num_fragments_total: u8,
     pub buffer: Vec<u8>,
-    pub fragments_received: [bool; MAX_FRAGMENTS_DEFAULT as usize]
+    pub fragments_received: [bool; MAX_FRAGMENTS_DEFAULT as usize],
 }
 
 impl ReassemblyData {
-    pub fn new(
-        sequence: u16,
-        ack: u16,
-        ack_bits: u32,
-        num_fragments_total: u8,
-        header_size: usize,
-        prealloc: usize,
-    ) -> Self {
+    pub fn new(sequence: u16, num_fragments_total: u8, prealloc: usize) -> Self {
         Self {
             sequence,
             num_fragments_received: 0,
@@ -36,7 +29,7 @@ impl Default for ReassemblyData {
             num_fragments_received: 0,
             num_fragments_total: 0,
             buffer: Vec::with_capacity(1024),
-            fragments_received: [false; MAX_FRAGMENTS_DEFAULT as usize]
+            fragments_received: [false; MAX_FRAGMENTS_DEFAULT as usize],
         }
     }
 }

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -30,7 +30,7 @@ impl ServerMoq {
         expected_payload: Vec<u8>,
     ) -> JoinHandle<u32> {
         let mut udp_socket: UdpSocket = UdpSocket::bind(self.host, self.config.clone()).unwrap();
-        udp_socket.set_nonblocking(self.non_blocking);
+        udp_socket.set_nonblocking(self.non_blocking).unwrap();
 
         let mut packet_throughput = 0;
         let mut packets_total_received = 0;
@@ -47,7 +47,7 @@ impl ServerMoq {
                         packets_total_received += 1;
                         packet_throughput += 1;
 
-                        udp_socket.send(packet);
+                        udp_socket.send(packet).unwrap();
                     }
                     Ok(None) => {}
                     Err(_) => {
@@ -96,7 +96,8 @@ impl ServerMoq {
                     Err(_) => {}
                 }
 
-                let send_result = client.send(Packet::sequenced_unordered(host, data_to_send.clone()));
+                let send_result =
+                    client.send(Packet::sequenced_unordered(host, data_to_send.clone()));
 
                 if len <= config.fragment_size as usize {
                     assert_eq!(

--- a/tests/fragments.rs
+++ b/tests/fragments.rs
@@ -26,15 +26,22 @@ pub fn fragment_packet_integration_test() {
     let mut server = ServerMoq::new(NetworkConfig::default(), true, SERVER_ADDR.parse().unwrap());
     let server_thread = server.start_receiving(rx, test_data.clone());
 
-    let client = ClientStub::new(Duration::from_millis(0), CLIENT_ADDR.parse().unwrap(), TOTAL_PACKETS_TO_SEND);
+    let client = ClientStub::new(
+        Duration::from_millis(0),
+        CLIENT_ADDR.parse().unwrap(),
+        TOTAL_PACKETS_TO_SEND,
+    );
 
     let stopwatch = Instant::now();
 
-    server.add_client(test_data.to_vec(), client).join();
+    server
+        .add_client(test_data.to_vec(), client)
+        .join()
+        .unwrap();
 
     // notify server to stop receiving.
-    tx.send(true);
+    tx.send(true).unwrap();
 
-    let total_received = server_thread.join().unwrap();
-    let elapsed_time = stopwatch.elapsed();
+    let _total_received = server_thread.join().unwrap();
+    let _elapsed_time = stopwatch.elapsed();
 }

--- a/tests/multiple_clients.rs
+++ b/tests/multiple_clients.rs
@@ -32,12 +32,36 @@ pub fn multiple_client_integration_test() {
 
     // create client stubs.
     let mut clients = Vec::new();
-    clients.push(ClientStub::new(sixteenth_a_second, "127.0.0.1:12346".parse().unwrap(), TOTAL_PACKETS_TO_SEND));
-    clients.push(ClientStub::new(sixteenth_a_second, "127.0.0.1:12347".parse().unwrap(), TOTAL_PACKETS_TO_SEND));
-    clients.push(ClientStub::new(sixteenth_a_second, "127.0.0.1:12348".parse().unwrap(), TOTAL_PACKETS_TO_SEND));
-    clients.push(ClientStub::new(sixteenth_a_second, "127.0.0.1:12349".parse().unwrap(), TOTAL_PACKETS_TO_SEND));
-    clients.push(ClientStub::new(sixteenth_a_second, "127.0.0.1:12350".parse().unwrap(), TOTAL_PACKETS_TO_SEND));
-    clients.push(ClientStub::new(sixteenth_a_second, "127.0.0.1:12351".parse().unwrap(), TOTAL_PACKETS_TO_SEND));
+    clients.push(ClientStub::new(
+        sixteenth_a_second,
+        "127.0.0.1:12346".parse().unwrap(),
+        TOTAL_PACKETS_TO_SEND,
+    ));
+    clients.push(ClientStub::new(
+        sixteenth_a_second,
+        "127.0.0.1:12347".parse().unwrap(),
+        TOTAL_PACKETS_TO_SEND,
+    ));
+    clients.push(ClientStub::new(
+        sixteenth_a_second,
+        "127.0.0.1:12348".parse().unwrap(),
+        TOTAL_PACKETS_TO_SEND,
+    ));
+    clients.push(ClientStub::new(
+        sixteenth_a_second,
+        "127.0.0.1:12349".parse().unwrap(),
+        TOTAL_PACKETS_TO_SEND,
+    ));
+    clients.push(ClientStub::new(
+        sixteenth_a_second,
+        "127.0.0.1:12350".parse().unwrap(),
+        TOTAL_PACKETS_TO_SEND,
+    ));
+    clients.push(ClientStub::new(
+        sixteenth_a_second,
+        "127.0.0.1:12351".parse().unwrap(),
+        TOTAL_PACKETS_TO_SEND,
+    ));
 
     let stopwatch = Instant::now();
 
@@ -50,12 +74,12 @@ pub fn multiple_client_integration_test() {
 
     // wait for clients to send data
     for handle in handles {
-        handle.join();
+        handle.join().unwrap();
     }
 
     // notify server to stop receiving.
-    tx.send(true);
+    tx.send(true).unwrap();
 
-    let total_received = server_thread.join().unwrap();
-    let elapsed_time = stopwatch.elapsed();
+    let _total_received = server_thread.join().unwrap();
+    let _elapsed_time = stopwatch.elapsed();
 }

--- a/tests/normal.rs
+++ b/tests/normal.rs
@@ -26,7 +26,11 @@ pub fn normal_packet_integration_test() {
     let mut server = ServerMoq::new(NetworkConfig::default(), true, SERVER_ADDR.parse().unwrap());
     let server_thread = server.start_receiving(rx, test_data.to_vec());
 
-    let client = ClientStub::new(Duration::from_millis(0), CLIENT_ADDR.parse().unwrap(), TOTAL_PACKETS_TO_SEND);
+    let client = ClientStub::new(
+        Duration::from_millis(0),
+        CLIENT_ADDR.parse().unwrap(),
+        TOTAL_PACKETS_TO_SEND,
+    );
 
     let stopwatch = Instant::now();
 
@@ -35,6 +39,6 @@ pub fn normal_packet_integration_test() {
     // notify server to stop receiving.
     tx.send(true);
 
-    let total_received = server_thread.join().unwrap();
-    let elapsed_time = stopwatch.elapsed();
+    let _total_received = server_thread.join().unwrap();
+    let _elapsed_time = stopwatch.elapsed();
 }


### PR DESCRIPTION
This cleans up many warnings produced in a regular build. There are still quite a few warnings in the tests and there are about 4 left in the main crate. I believe those will go away once timeout removals are in.