### PR TITLE
Fix some clippy warnings.

### DIFF
--- a/src/net/connection/connection_pool.rs
+++ b/src/net/connection/connection_pool.rs
@@ -71,13 +71,12 @@ impl ConnectionPool {
         let connections = self.connections.clone();
         let poll_interval = self.poll_interval;
 
-        let sender = events_sender.clone();
         Ok(thread::Builder::new()
             .name("check_for_timeouts".into())
             .spawn(move || loop {
                 match connections.read() {
                     Ok(lock) => {
-                        ConnectionPool::check_for_timeouts(&*lock, poll_interval, &sender);
+                        ConnectionPool::check_for_timeouts(&*lock, poll_interval, &events_sender);
                     }
                     Err(e) => {
                         panic!("Error when checking for timed out connections: {}", e)

--- a/src/net/connection/quality.rs
+++ b/src/net/connection/quality.rs
@@ -57,7 +57,7 @@ impl NetworkQualityMeasurer {
     /// `as_milliseconds` is not supported yet supported in rust stable.
     /// See this stackoverflow post for more info: https://stackoverflow.com/questions/36816072/how-do-i-get-a-duration-as-a-number-of-milliseconds-in-rust
     fn as_milliseconds(&self, duration: Duration) -> u64 {
-        let nanos = duration.subsec_nanos() as u64;
+        let nanos = u64::from(duration.subsec_nanos());
         (1000 * 1000 * 1000 * duration.as_secs() + nanos) / (1000 * 1000)
     }
 
@@ -70,7 +70,7 @@ impl NetworkQualityMeasurer {
     /// We do this so that if one packet has an bad rtt it will not directly bring down the or network quality estimation.
     /// The default is 10% smoothing so if in total or packet is 50 milliseconds later than max allowed rtt we will increase or rtt estimation with 5.
     fn smooth_out_rtt(&self, rtt: u64) -> f32 {
-        let exceeded_rrt_time = rtt as i64 - self.config.rtt_max_value as i64;
+        let exceeded_rrt_time = rtt as i64 - i64::from(self.config.rtt_max_value);
         exceeded_rrt_time as f32 * self.config.rtt_smoothing_factor
     }
 }

--- a/src/net/constants.rs
+++ b/src/net/constants.rs
@@ -16,4 +16,4 @@ pub const DEFAULT_MTU: u16 = 1452;
 /// It is used for:
 /// - Generating crc32 for the packet header.
 /// - Validating if arriving packets have the same protocol version.
-pub const PROTOCOL_VERSION: &'static str = "laminar-0.1.0";
+pub const PROTOCOL_VERSION: &str = "laminar-0.1.0";

--- a/src/net/external_ack.rs
+++ b/src/net/external_ack.rs
@@ -36,7 +36,7 @@ impl ExternalAcks {
             // If the packet is more recent, we update the remote sequence to be equal to the sequence number of the packet.
             self.last_seq = seq_num;
         } else if neg_diff <= 32 {
-            self.field |= 1 << neg_diff - 1;
+            self.field |= 1 << (neg_diff - 1);
         }
     }
 }

--- a/src/net/local_ack.rs
+++ b/src/net/local_ack.rs
@@ -36,12 +36,12 @@ impl LocalAckRecord {
         let mut dropped_packets = Vec::new();
         let mut acked_packets = Vec::new();
 
-        for key in self.packets.keys().into_iter() {
+        for key in self.packets.keys() {
             let diff = seq.wrapping_sub(*key);
             if diff == 0 {
                 acked_packets.push(*key);
             } else if diff <= 32 {
-                let field_acked = (seq_field & (1 << diff - 1) != 0);
+                let field_acked = (seq_field & (1 << (diff - 1)) != 0);
                 if field_acked {
                     acked_packets.push(*key);
                 }
@@ -50,7 +50,7 @@ impl LocalAckRecord {
             }
         }
 
-        for seq_number in acked_packets.iter() {
+        for seq_number in &acked_packets {
             self.packets.remove(seq_number);
         }
 

--- a/src/net/socket_state.rs
+++ b/src/net/socket_state.rs
@@ -107,11 +107,11 @@ impl SocketState {
 
             for fragment_id in 0..num_fragments {
                 let fragment =
-                    FragmentHeader::new(fragment_id, num_fragments, packet_header.clone());
+                    FragmentHeader::new(fragment_id, num_fragments, packet_header);
 
                 // get start end pos in buffer
-                let start_fragment_pos = fragment_id as u16 * config.fragment_size; /* upcast is safe */
-                let mut end_fragment_pos = (fragment_id as u16 + 1) * config.fragment_size; /* upcast is safe */
+                let start_fragment_pos = u16::from(fragment_id) * config.fragment_size; /* upcast is safe */
+                let mut end_fragment_pos = (u16::from(fragment_id) + 1) * config.fragment_size; /* upcast is safe */
 
                 // If remaining buffer fits int one packet just set the end position to the length of the packet payload.
                 if end_fragment_pos > payload_length {

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -41,7 +41,6 @@ impl UdpSocket {
 
             self.packet_processor
                 .process_data(packet, addr, &mut self.state)
-                .map_err(|err| err.into())
         } else {
             Err(NetworkErrorKind::ReceivedDataToShort)?
         }

--- a/src/packet/header/heart_beat_header.rs
+++ b/src/packet/header/heart_beat_header.rs
@@ -22,6 +22,12 @@ impl HeartBeatHeader {
     }
 }
 
+impl Default for HeartBeatHeader {
+    fn default() -> Self {
+        HeartBeatHeader::new()
+    }
+}
+
 impl HeaderParser for HeartBeatHeader {
     type Output = NetworkResult<Vec<u8>>;
 
@@ -49,6 +55,6 @@ impl HeaderReader for HeartBeatHeader {
 
     /// Get the size of this header.
     fn size(&self) -> u8 {
-        return HEART_BEAT_HEADER_SIZE;
+        HEART_BEAT_HEADER_SIZE
     }
 }

--- a/src/packet/packet.rs
+++ b/src/packet/packet.rs
@@ -99,7 +99,7 @@ impl Packet {
 
     /// Get the payload (raw data) of this packet.
     pub fn payload(&self) -> &[u8] {
-        return &self.payload;
+        &self.payload
     }
 
     /// Get the endpoint from this packet.

--- a/src/packet/packet_data.rs
+++ b/src/packet/packet_data.rs
@@ -4,7 +4,7 @@ use super::RawPacketData;
 use error::NetworkResult;
 
 /// Contains the raw data this packet exists of. Note that a packet can be divided into separate fragments
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct PacketData {
     parts: Vec<RawPacketData>,
 }
@@ -38,7 +38,7 @@ impl PacketData {
     pub fn parts(&mut self) -> Vec<Vec<u8>> {
         let mut parts_data: Vec<Vec<u8>> = Vec::new();
 
-        for part in self.parts.iter_mut() {
+        for part in &mut self.parts {
             parts_data.push(part.serialize());
         }
 

--- a/src/packet/packet_processor.rs
+++ b/src/packet/packet_processor.rs
@@ -55,11 +55,11 @@ impl PacketProcessor {
             _ => Ok(None),
         };
 
-        return match received_bytes {
+        match received_bytes {
             Ok(Some(payload)) => Ok(Some(Packet::sequenced_unordered(addr, payload))),
             Ok(None) => Ok(None),
             Err(e) => Err(e)?,
-        };
+        }
     }
 
     /// Extract fragments from data.
@@ -115,7 +115,7 @@ impl PacketProcessor {
             return Ok(Some(total_buffer));
         }
 
-        return Ok(None);
+        Ok(None)
     }
 
     /// Extract header and data from normal packet.

--- a/src/protocol_version.rs
+++ b/src/protocol_version.rs
@@ -15,16 +15,33 @@ pub struct ProtocolVersion;
 impl ProtocolVersion {
     /// Get the current protocol version.
     pub fn get_version() -> &'static str {
-        return PROTOCOL_VERSION;
+        PROTOCOL_VERSION
     }
 
     /// This will return the crc32 from the current protocol version.
     pub fn get_crc32() -> u32 {
-        VERSION_CRC32.lock().unwrap().clone()
+        *VERSION_CRC32.lock().unwrap()
     }
 
     /// Validate a crc32 with the current protocol version and return the results.
     pub fn valid_version(protocol_version_crc32: u32) -> bool {
-        protocol_version_crc32 == VERSION_CRC32.lock().unwrap().clone()
+        protocol_version_crc32 == *VERSION_CRC32.lock().unwrap()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn valid_version() {
+        let protocol_id = crc32::checksum_ieee(PROTOCOL_VERSION.as_bytes());
+        assert!(ProtocolVersion::valid_version(protocol_id));
+    }
+
+    #[test]
+    fn not_valid_version() {
+        let protocol_id = crc32::checksum_ieee("not-laminar".as_bytes());
+        assert!(!ProtocolVersion::valid_version(protocol_id));
     }
 }

--- a/src/sequence_buffer/sequence_buffer.rs
+++ b/src/sequence_buffer/sequence_buffer.rs
@@ -57,7 +57,7 @@ impl<T> SequenceBuffer<T> where T: Default + Clone + Send + Sync {
             return false;
         }
 
-        return true;
+        true
     }
 
     /// Get the length of the collection.


### PR DESCRIPTION
This fixes some easy clippy warnings. There are two clippy errors due to usage of `write` when `write_all` could be used. I'll make sure it's really ok to use `write_all` later (it's probably really better given than clippy tags it as an error).
(I also added some trivial tests in `src/protocol_version.rs` in the same move)