### PR TITLE
Fix bors unable to clone staging.tmp issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,18 @@ rust:
   - beta
   - nightly
 
+os:
+- linux
+- osx
+- windows
+
+branches:
+  only:
+    - staging
+    - trying
+    - master
+    - /release-.*/
+
 # Allow for occasional compiler breakage on nightly Rust.
 matrix:
   allow_failures:

--- a/bors.toml
+++ b/bors.toml
@@ -10,9 +10,3 @@ block_labels = [
     "status: wontfix",
     "status: working"
 ]
-
-# This feature is rarely useful and more often problematic, so we turn it off.
-delete_merged_branches = false
-
-# Increase timeout to 5 hours as the default timeout is too short for our build
-timeout_sec = 18000


### PR DESCRIPTION
This also adds windows, osx and linux to the travis test suite.