### PR TITLE
Implemented re sending of packets.

### DIFF
--- a/src/net/connection/virtual_connection.rs
+++ b/src/net/connection/virtual_connection.rs
@@ -109,6 +109,17 @@ impl VirtualConnection {
 
         Ok(Some(Packet::new(self.remote_address, Box::from(payload), header.delivery_method)))
     }
+
+    /// This will gather dropped packets from the reliable channels.
+    ///
+    /// Note that after requesting dropped packets the dropped packets will be removed from this client.
+    pub fn gather_dropped_packets(&mut self) -> Vec<Box<[u8]>> {
+        if self.reliable_unordered_channel.has_dropped_packets() {
+            return self.reliable_unordered_channel.drain_dropped_packets();
+        }
+
+        Vec::new()
+    }
 }
 
 impl fmt::Debug for VirtualConnection {
@@ -127,7 +138,7 @@ mod tests {
     use net::NetworkConfig;
     use net::connection::VirtualConnection;
     use packet::header::{AckedPacketHeader, StandardHeader, HeaderReader, HeaderParser};
-    use infrastructure::DeliveryMethod;
+    use infrastructure::{DeliveryMethod, ReliableChannel, Channel};
     use packet::PacketTypeId;
     use net::constants::STANDARD_HEADER_SIZE;
     use std::sync::Arc;


### PR DESCRIPTION
I have created a function called: `gather_dropped_packets()` this will gather dropped packets by draining them from all reliable channels. This function is called in `udp.rs` `send()` so that before the user his packet goes out there will be a check if there are dropped packets that needs to be resend, if there are those will be resend until they are being aknowleged.

**A question I have:**

I don't know how to test whether this really works. Like our acknowledgment system has unit-test for it. But I can't specify check if dropped packets are resent using our UDP socket. @fhaynes is there a way this could be covered by your scenario tests?