### PR TITLE
Added lints.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,5 @@ matrix:
   fast_finish: true
 
 script:
+  - cargo clippy
   - cargo test --verbose --all --all-features

--- a/src/infrastructure/channels/mod.rs
+++ b/src/infrastructure/channels/mod.rs
@@ -7,7 +7,6 @@ mod reliable_channel;
 use infrastructure::DeliveryMethod;
 use error::NetworkResult;
 use packet::PacketData;
-use std::io::Cursor;
 
 pub use self::unreliable_channel::UnreliableChannel;
 pub use self::sequenced_channel::SequencedChannel;

--- a/src/infrastructure/channels/reliable_channel.rs
+++ b/src/infrastructure/channels/reliable_channel.rs
@@ -5,9 +5,9 @@ use packet::header::{HeaderParser, HeaderReader, AckedPacketHeader, StandardHead
 use sequence_buffer::{SequenceBuffer, CongestionData};
 use infrastructure::{DeliveryMethod, Fragmentation};
 use error::{PacketErrorKind,NetworkResult};
-use packet::{Packet, PacketData,PacketTypeId};
+use packet::{PacketData,PacketTypeId};
 
-use std::io::{Cursor, Read};
+use std::io::Cursor;
 use std::time::Instant;
 use std::sync::Arc;
 

--- a/src/infrastructure/channels/sequenced_channel.rs
+++ b/src/infrastructure/channels/sequenced_channel.rs
@@ -4,8 +4,6 @@ use packet::PacketData;
 use infrastructure::DeliveryMethod;
 use error::NetworkResult;
 
-use std::io::Cursor;
-
 /// This channel should be used for processing packets sequenced.
 ///
 /// *Details*

--- a/src/infrastructure/channels/unreliable_channel.rs
+++ b/src/infrastructure/channels/unreliable_channel.rs
@@ -6,8 +6,6 @@ use infrastructure::DeliveryMethod;
 use packet::{PacketData, PacketTypeId};
 use error::NetworkResult;
 
-use std::io::{Cursor, Read};
-
 /// This channel should be used for unreliable processing of packets.
 ///
 /// **Details**

--- a/src/infrastructure/fragmenter.rs
+++ b/src/infrastructure/fragmenter.rs
@@ -125,7 +125,7 @@ impl Fragmentation {
             cursor.read_to_end(&mut payload)?;
 
             // add the payload from the fragment to the buffer whe have in cache
-            reassembly_data.buffer.write(payload.as_slice())?;
+            reassembly_data.buffer.write_all(payload.as_slice())?;
 
             num_fragments_received = reassembly_data.num_fragments_received;
             num_fragments_total = reassembly_data.num_fragments_total;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,6 @@
 #![warn(missing_docs)]
 #![deny(unused_imports)]
 
-
 extern crate bincode;
 extern crate byteorder;
 extern crate crc;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,11 @@
 //! }
 //! ```
 
+#![cfg_attr(feature = "cargo-clippy", deny(needless_return))]
+#![warn(missing_docs)]
+#![deny(unused_imports)]
+
+
 extern crate bincode;
 extern crate byteorder;
 extern crate crc;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,14 +45,20 @@
 
 #![cfg_attr(feature = "cargo-clippy", deny(needless_return))]
 #![warn(missing_docs)]
-#![deny(unused_imports)]
+#[deny(
+trivial_casts,
+trivial_numeric_casts,
+unused_extern_crates,
+unused_import_braces,
+unused_qualifications,
+unused_results,
+unused_imports
+)]
 
-extern crate bincode;
 extern crate byteorder;
 extern crate crc;
 #[macro_use]
 extern crate lazy_static;
-extern crate serde;
 
 #[macro_use]
 extern crate log;

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -59,7 +59,7 @@ impl UdpSocket {
                 .write()
                 .map_err(|error| NetworkError::poisoned_connection_error(error.description()))?;
 
-            return lock.process_incoming(&packet)
+            lock.process_incoming(&packet)
 
         } else {
             Err(NetworkErrorKind::ReceivedDataToShort)?

--- a/src/packet/packet_data.rs
+++ b/src/packet/packet_data.rs
@@ -17,8 +17,8 @@ impl PacketData {
     /// Add fragment to this packet
     pub fn add_fragment(&mut self, fragment: &[u8], fragment_data: &[u8]) -> NetworkResult<()> {
         let mut part = Vec::with_capacity(fragment.len() + fragment_data.len());
-        part.write(fragment)?;
-        part.write(fragment_data)?;
+        part.write_all(fragment)?;
+        part.write_all(fragment_data)?;
         self.parts.push(part);
         Ok(())
     }

--- a/src/protocol_version.rs
+++ b/src/protocol_version.rs
@@ -1,7 +1,6 @@
 use std::sync::Mutex;
 
 use crc::crc32;
-use lazy_static;
 
 pub use net::constants::PROTOCOL_VERSION;
 


### PR DESCRIPTION
Added some lints:

**Warn**
- missingdocs

**Deny**
- missing_doc,
- unused_imports
- needles return lint.
- trivial_casts,
- trivial_numeric_casts,
- unused_extern_crates,
- unused_import_braces,
- unused_qualifications,
- unused_results,
- unused_imports
- needless_return

See #72 #80 

Please let me know if you have more. Note that I did not fix all warning I'll do that in another PR to keep the PR's small. I will fix errors other hand.

If you are not sure what the clippy lint means check [this](https://rust-lang-nursery.github.io/rust-clippy/master/index.html) out.