### PR TITLE
Fix code style via rustfmt

### DIFF
--- a/examples/server_client.rs
+++ b/examples/server_client.rs
@@ -6,12 +6,7 @@ extern crate laminar;
 
 use std::io::stdin;
 
-use laminar::{
-    error::Result,
-    config::NetworkConfig,
-    net::UdpSocket,
-    Packet,
-};
+use laminar::{config::NetworkConfig, error::Result, net::UdpSocket, Packet};
 
 const SERVER: &str = "localhost:12351";
 

--- a/examples/simple_udp.rs
+++ b/examples/simple_udp.rs
@@ -10,10 +10,7 @@ extern crate serde_derive;
 
 use bincode::{deserialize, serialize};
 use laminar::config::NetworkConfig;
-use laminar::{
-    net::UdpSocket,
-    Packet,
-};
+use laminar::{net::UdpSocket, Packet};
 use serde_derive::{Deserialize, Serialize};
 use std::net::SocketAddr;
 use std::{thread, time};

--- a/examples/udp.rs
+++ b/examples/udp.rs
@@ -5,11 +5,7 @@
 
 extern crate laminar;
 
-use laminar::{
-    net::UdpSocket,
-    config::NetworkConfig,
-    Packet,
-};
+use laminar::{config::NetworkConfig, net::UdpSocket, Packet};
 
 use std::net::SocketAddr;
 

--- a/src/bin/laminar-tester.rs
+++ b/src/bin/laminar-tester.rs
@@ -13,7 +13,7 @@ use std::time::{Duration, Instant};
 
 use clap::App;
 
-use laminar::{net, DeliveryMethod, Packet, config};
+use laminar::{config, net, DeliveryMethod, Packet};
 
 fn main() {
     let yaml = load_yaml!("cli.yml");

--- a/src/error/network_error.rs
+++ b/src/error/network_error.rs
@@ -43,7 +43,10 @@ pub enum NetworkErrorKind {
     #[fail(display = "The protocol versions do not match.")]
     /// Protocol versions did not match
     ProtocolVersionMismatch,
-    #[fail(display = "Something went wrong with connection timeout thread. Reason: {:?}", _0)]
+    #[fail(
+        display = "Something went wrong with connection timeout thread. Reason: {:?}",
+        _0
+    )]
     /// Error occurred in connection pool.
     ConnectionPoolError(String),
     #[fail(display = "Joining thread failed.")]

--- a/src/events.rs
+++ b/src/events.rs
@@ -25,8 +25,8 @@ pub enum Event {
 #[cfg(test)]
 mod test {
     use super::Event;
-    use net::VirtualConnection;
     use config::NetworkConfig;
+    use net::VirtualConnection;
     use std::net::ToSocketAddrs;
     use std::sync::{Arc, RwLock};
 

--- a/src/infrastructure/channels/reliable_channel.rs
+++ b/src/infrastructure/channels/reliable_channel.rs
@@ -1,9 +1,9 @@
 use super::Channel;
 
+use config::NetworkConfig;
 use error::{NetworkResult, PacketErrorKind};
 use infrastructure::{DeliveryMethod, Fragmentation};
 use net::{ExternalAcks, LocalAckRecord, NetworkQuality, RttMeasurer};
-use config::NetworkConfig;
 use packet::header::{AckedPacketHeader, HeaderParser, HeaderReader, StandardHeader};
 use packet::{PacketData, PacketTypeId};
 use sequence_buffer::{CongestionData, SequenceBuffer};

--- a/src/infrastructure/fragmenter.rs
+++ b/src/infrastructure/fragmenter.rs
@@ -1,5 +1,5 @@
-use error::{FragmentErrorKind, NetworkResult};
 use config::NetworkConfig;
+use error::{FragmentErrorKind, NetworkResult};
 use packet::header::{AckedPacketHeader, FragmentHeader, HeaderParser, HeaderReader};
 use packet::PacketData;
 use sequence_buffer::{ReassemblyData, SequenceBuffer};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,16 +61,15 @@ mod packet;
 mod protocol_version;
 mod sequence_buffer;
 
-
+/// Contains networking related configuration
+pub mod config;
 /// All internal error handling logic
 pub mod error;
 /// Networking modules
 pub mod net;
-/// Contains networking related configuration
-pub mod config;
 
+pub use config::NetworkConfig;
 pub use events::Event;
 pub use infrastructure::DeliveryMethod;
 pub use packet::Packet;
 pub use protocol_version::ProtocolVersion;
-pub use config::NetworkConfig;

--- a/src/net/connection/mod.rs
+++ b/src/net/connection/mod.rs
@@ -1,16 +1,16 @@
 mod connection_pool;
 mod quality;
-mod virtual_connection;
 mod timeout_thread;
+mod virtual_connection;
 
 pub use self::connection_pool::ConnectionPool;
 pub use self::quality::{NetworkQuality, RttMeasurer};
-pub use self::virtual_connection::VirtualConnection;
 pub use self::timeout_thread::TimeoutThread;
+pub use self::virtual_connection::VirtualConnection;
 
-use std::sync::{Arc, RwLock};
-use std::net::SocketAddr;
 use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::{Arc, RwLock};
 
 pub type Connection = Arc<RwLock<VirtualConnection>>;
 pub type Connections = HashMap<SocketAddr, Connection>;

--- a/src/net/connection/quality.rs
+++ b/src/net/connection/quality.rs
@@ -72,8 +72,8 @@ impl RttMeasurer {
 #[cfg(test)]
 mod test {
     use super::RttMeasurer;
-    use net::connection::VirtualConnection;
     use config::NetworkConfig;
+    use net::connection::VirtualConnection;
     use std::net::ToSocketAddrs;
     use std::sync::Arc;
     use std::time::Duration;

--- a/src/net/connection/timeout_thread.rs
+++ b/src/net/connection/timeout_thread.rs
@@ -1,10 +1,10 @@
 use super::ConnectionPool;
-use error::{NetworkResult, NetworkErrorKind, NetworkError};
+use error::{NetworkError, NetworkErrorKind, NetworkResult};
 use events::Event;
 
-use std::thread;
-use std::sync::mpsc::{channel, Sender, Receiver};
+use std::sync::mpsc::{channel, Receiver, Sender};
 use std::sync::Arc;
+use std::thread;
 use std::time::Duration;
 
 // Default time between checks of all clients for timeouts in seconds
@@ -21,50 +21,51 @@ pub const TIMEOUT_POLL_INTERVAL: u64 = 1;
 pub struct TimeoutThread {
     poll_interval: Duration,
     timeout_check_thread: Option<thread::JoinHandle<()>>,
-    sender:  Sender<Event>,
-    connection_pool: Arc<ConnectionPool>
+    sender: Sender<Event>,
+    connection_pool: Arc<ConnectionPool>,
 }
 
 impl TimeoutThread {
-    pub fn new(events_sender: Sender<Event>, connection_pool: &Arc<ConnectionPool>) -> TimeoutThread {
+    pub fn new(
+        events_sender: Sender<Event>,
+        connection_pool: &Arc<ConnectionPool>,
+    ) -> TimeoutThread {
         let poll_interval = Duration::from_secs(TIMEOUT_POLL_INTERVAL);
 
         TimeoutThread {
             poll_interval,
             timeout_check_thread: None,
             sender: events_sender,
-            connection_pool: connection_pool.clone()
+            connection_pool: connection_pool.clone(),
         }
     }
 
     /// Start the timeout thread which will check for idling clients.
     ///
     /// This will return a `Receiver` on witch error messages will be send.
-    pub fn start(
-        &mut self,
-    ) -> NetworkResult<Receiver<NetworkError>> {
+    pub fn start(&mut self) -> NetworkResult<Receiver<NetworkError>> {
         let connection_pool = self.connection_pool.clone();
         let poll_interval = self.poll_interval;
         let sender = self.sender.clone();
         let (tx, rx) = channel();
 
-        let thread = thread::spawn(move ||
-            loop {
-                match connection_pool.check_for_timeouts(poll_interval, &sender) {
-                    Ok(timed_out_clients) => {
-                        for timed_out_client in timed_out_clients {
-                            if let Err(e) = connection_pool.remove_connection(&timed_out_client) {
-                                tx.send(e)
+        let thread = thread::spawn(move || loop {
+            match connection_pool.check_for_timeouts(poll_interval, &sender) {
+                Ok(timed_out_clients) => {
+                    for timed_out_client in timed_out_clients {
+                        if let Err(e) = connection_pool.remove_connection(&timed_out_client) {
+                            tx.send(e)
                                     .expect("The corresponding receiver for the error message channel has already been deallocated.");
-                            }
                         }
-                    },
-                    Err(e) => { let _ = tx.send(e); },
+                    }
                 }
-
-                thread::sleep(poll_interval);
+                Err(e) => {
+                    let _ = tx.send(e);
+                }
             }
-        );
+
+            thread::sleep(poll_interval);
+        });
 
         self.timeout_check_thread = Some(thread);
         Ok(rx)
@@ -75,7 +76,8 @@ impl TimeoutThread {
     pub fn stop(self) -> NetworkResult<()> {
         let handler = self.timeout_check_thread;
         if let Some(handle) = handler {
-            handle.join()
+            handle
+                .join()
                 .map_err(|_| NetworkErrorKind::JoiningThreadFailed)?;
         }
         Ok(())

--- a/src/net/connection/virtual_connection.rs
+++ b/src/net/connection/virtual_connection.rs
@@ -1,8 +1,8 @@
+use config::NetworkConfig;
 use error::{NetworkErrorKind, NetworkResult};
 use infrastructure::{
     Channel, DeliveryMethod, Fragmentation, ReliableChannel, SequencedChannel, UnreliableChannel,
 };
-use config::NetworkConfig;
 use packet::header::HeaderReader;
 use packet::header::StandardHeader;
 use packet::{Packet, PacketData, PacketTypeId};
@@ -154,9 +154,9 @@ impl fmt::Debug for VirtualConnection {
 
 #[cfg(test)]
 mod tests {
+    use config::NetworkConfig;
     use infrastructure::DeliveryMethod;
     use net::connection::VirtualConnection;
-    use config::NetworkConfig;
     use std::sync::Arc;
 
     const SERVER_ADDR: &str = "127.0.0.1:12345";

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -1,10 +1,10 @@
 use net::connection::{ConnectionPool, TimeoutThread};
 use std::net::{self, SocketAddr, ToSocketAddrs};
 
+use config::NetworkConfig;
 use error::{NetworkError, NetworkErrorKind, NetworkResult};
 use events::Event;
 use net::link_conditioner::LinkConditioner;
-use config::NetworkConfig;
 use packet::Packet;
 
 use std::error::Error;

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,10 +1,6 @@
 extern crate laminar;
 
-use laminar::{
-    net::UdpSocket,
-    config::NetworkConfig,
-    DeliveryMethod, Packet,
-};
+use laminar::{config::NetworkConfig, net::UdpSocket, DeliveryMethod, Packet};
 use std::{
     net::SocketAddr,
     sync::mpsc::Receiver,

--- a/tests/fragments.rs
+++ b/tests/fragments.rs
@@ -2,8 +2,8 @@ extern crate laminar;
 
 mod common;
 
-use laminar::DeliveryMethod;
 use laminar::config::NetworkConfig;
+use laminar::DeliveryMethod;
 use std::{
     sync::mpsc,
     time::{Duration, Instant},

--- a/tests/multiple_clients.rs
+++ b/tests/multiple_clients.rs
@@ -5,8 +5,8 @@ mod common;
 use std::sync::mpsc;
 use std::time::{Duration, Instant};
 
-use laminar::DeliveryMethod;
 use laminar::config::NetworkConfig;
+use laminar::DeliveryMethod;
 
 use common::{ClientStub, ServerMoq};
 

--- a/tests/normal.rs
+++ b/tests/normal.rs
@@ -2,8 +2,8 @@ extern crate laminar;
 
 mod common;
 
-use laminar::DeliveryMethod;
 use laminar::config::NetworkConfig;
+use laminar::DeliveryMethod;
 use std::{
     sync::mpsc,
     time::{Duration, Instant},


### PR DESCRIPTION
This formats our codebase with rustfmt:

```bash
$ cargo fmt --version
rustfmt 0.99.4-stable (1c408818 2018-08-27)
```