### PR TITLE
Add rustfmt check to travis stable builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
     - rust: rustfmt
       script:
         - rustup component add rustfmt-preview
-        - cargo +stable fmt -- --write-mode=diff
+        - cargo fmt -- --write-mode=diff
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,10 +28,10 @@ matrix:
     - rust: nightly
   fast_finish: true
   include:
-    - rust: rustfmt
+    - rust: stable
       script:
         - rustup component add rustfmt-preview
-        - cargo fmt -- --write-mode=diff
+        - cargo fmt -- --check
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,11 +28,10 @@ matrix:
     - rust: nightly
   fast_finish: true
   include:
-    - rust: stable
+    - rust: rustfmt
       script:
-        - cargo test --all --all-features --locked
         - rustup component add rustfmt-preview
-        - cargo fmt -- --write-mode=diff
+        - cargo +stable fmt -- --write-mode=diff
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,13 @@ branches:
 matrix:
   allow_failures:
     - rust: nightly
-    - rust: beta
   fast_finish: true
+  include:
+    - rust: stable
+      script:
+        - cargo test --all --all-features --locked
+        - rustup component add rustfmt-preview
+        - cargo fmt -- --write-mode=diff
 
 addons:
   apt:

--- a/src/infrastructure/delivery_method.rs
+++ b/src/infrastructure/delivery_method.rs
@@ -2,7 +2,6 @@
 ///
 /// This is a very important concept which could at first be difficult to grasp, but which will be very handy later on.
 ///
-/// 
 /// When dealing with networking for games, the two protocols that see the most use are TCP and UDP.
 /// UDP is considered to be more unreliable than TCP because it lacks certain features TCP has, as shown below.
 ///


### PR DESCRIPTION
This change adds a rustfmt check on the stable builds done on travis
ci. This is to ensure that all code that is commited to master follows
rustfmt stable.