### PR TITLE
Remove the mutex around VERSION_CRC32

### DIFF
--- a/src/protocol_version.rs
+++ b/src/protocol_version.rs
@@ -1,5 +1,3 @@
-use std::sync::Mutex;
-
 use crc::crc32;
 use lazy_static::lazy_static;
 
@@ -7,7 +5,7 @@ pub use net::constants::PROTOCOL_VERSION;
 
 lazy_static! {
     // The CRC32 of the current protocol version.
-    static ref VERSION_CRC32: Mutex<u32> = Mutex::new(crc32::checksum_ieee(PROTOCOL_VERSION.as_bytes()));
+    static ref VERSION_CRC32: u32 = crc32::checksum_ieee(PROTOCOL_VERSION.as_bytes());
 }
 
 /// Wrapper to provide some functions to perform with the current protocol version.
@@ -15,24 +13,28 @@ pub struct ProtocolVersion;
 
 impl ProtocolVersion {
     /// Get the current protocol version.
+    #[inline]
     pub fn get_version() -> &'static str {
         PROTOCOL_VERSION
     }
 
     /// This will return the crc32 from the current protocol version.
+    #[inline]
     pub fn get_crc32() -> u32 {
-        *VERSION_CRC32.lock().unwrap()
+        *VERSION_CRC32
     }
 
     /// Validate a crc32 with the current protocol version and return the results.
+    #[inline]
     pub fn valid_version(protocol_version_crc32: u32) -> bool {
-        protocol_version_crc32 == *VERSION_CRC32.lock().unwrap()
+        protocol_version_crc32 == ProtocolVersion::get_crc32()
     }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
+    use net::constants::PROTOCOL_VERSION;
 
     #[test]
     fn valid_version() {
@@ -44,5 +46,15 @@ mod test {
     fn not_valid_version() {
         let protocol_id = crc32::checksum_ieee("not-laminar".as_bytes());
         assert!(!ProtocolVersion::valid_version(protocol_id));
+    }
+
+    #[test]
+    fn get_crc32() {
+        assert_eq!(ProtocolVersion::get_crc32(), *VERSION_CRC32);
+    }
+
+    #[test]
+    fn get_version() {
+        assert_eq!(ProtocolVersion::get_version(), PROTOCOL_VERSION);
     }
 }


### PR DESCRIPTION
I suspect locking and unwrapping the mutex is a bit slower than just getting a copy of the u32.