### PR TITLE
Fix #122 - TimeoutThread: Kill system thread when dropped

### DIFF
--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -17,6 +17,7 @@ pub struct UdpSocket {
     recv_buffer: Vec<u8>,
     _config: Arc<NetworkConfig>,
     link_conditioner: Option<LinkConditioner>,
+    _timeout_thread: TimeoutThread,
     timeout_error_channel: Receiver<NetworkError>,
     events: (Sender<Event>, Receiver<Event>),
     connections: Arc<ConnectionPool>,
@@ -41,6 +42,7 @@ impl UdpSocket {
             _config: config.clone(),
             link_conditioner: None,
             connections: connection_pool,
+            _timeout_thread: timeout_thread,
             timeout_error_channel,
             events: (tx, rx),
         })


### PR DESCRIPTION
This PR fixes the issue described in #122 where the underlying thread for `TimeoutThread` is not shut down upon termination of `TimeoutThread`.

This is done by implementing `Drop` for `TimeoutThread`, and adding `TimeoutThread` to `UdpSocket` so that it is dropped when the socket is dropped.