### PR TITLE
Replace methods which take &Arc with an Arc

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -40,7 +40,7 @@ mod test {
 
         let test_conn = Arc::new(RwLock::new(VirtualConnection::new(
             addr.next().unwrap(),
-            &Arc::new(NetworkConfig::default()),
+            Arc::new(NetworkConfig::default()),
         )));
         let _ = Event::Connected(test_conn);
     }

--- a/src/infrastructure/channels/reliable_channel.rs
+++ b/src/infrastructure/channels/reliable_channel.rs
@@ -150,12 +150,7 @@ impl Channel for ReliableChannel {
         if payload_length <= self.config.fragment_size {
             packet_data.add_fragment(&buffer, payload)?;
         } else {
-            Fragmentation::spit_into_fragments(
-                payload,
-                header,
-                &mut packet_data,
-                self.config.clone(),
-            )?;
+            Fragmentation::spit_into_fragments(payload, header, &mut packet_data, &self.config)?;
         }
 
         // increase local sequence number.

--- a/src/infrastructure/channels/reliable_channel.rs
+++ b/src/infrastructure/channels/reliable_channel.rs
@@ -43,7 +43,7 @@ pub struct ReliableChannel {
 
 impl ReliableChannel {
     /// Creates a new instance of the reliable channel by specifying if channel needs to order incoming packets.
-    pub fn new(ordered: bool, config: &Arc<NetworkConfig>) -> ReliableChannel {
+    pub fn new(ordered: bool, config: Arc<NetworkConfig>) -> ReliableChannel {
         ReliableChannel {
             // settings
             ordered,
@@ -150,7 +150,12 @@ impl Channel for ReliableChannel {
         if payload_length <= self.config.fragment_size {
             packet_data.add_fragment(&buffer, payload)?;
         } else {
-            Fragmentation::spit_into_fragments(payload, header, &mut packet_data, &self.config)?;
+            Fragmentation::spit_into_fragments(
+                payload,
+                header,
+                &mut packet_data,
+                self.config.clone(),
+            )?;
         }
 
         // increase local sequence number.

--- a/src/infrastructure/fragmenter.rs
+++ b/src/infrastructure/fragmenter.rs
@@ -65,7 +65,7 @@ impl Fragmentation {
         payload: &[u8],
         acked_header: AckedPacketHeader,
         packet_data: &mut PacketData,
-        config: Arc<NetworkConfig>,
+        config: &Arc<NetworkConfig>,
     ) -> NetworkResult<()> {
         let payload_length = payload.len() as u16;
         let num_fragments =

--- a/src/infrastructure/fragmenter.rs
+++ b/src/infrastructure/fragmenter.rs
@@ -15,10 +15,10 @@ pub struct Fragmentation {
 
 impl Fragmentation {
     /// Creates and returns a new Fragmentation
-    pub fn new(config: &Arc<NetworkConfig>) -> Fragmentation {
+    pub fn new(config: Arc<NetworkConfig>) -> Fragmentation {
         Fragmentation {
             fragments: SequenceBuffer::with_capacity(config.fragment_reassembly_buffer_size),
-            config: config.clone(),
+            config,
         }
     }
 
@@ -61,11 +61,11 @@ impl Fragmentation {
     }
 
     /// Split the given payload into fragments and write those fragments to the passed packet data.
-    pub fn spit_into_fragments<'d>(
-        payload: &'d [u8],
+    pub fn spit_into_fragments(
+        payload: &[u8],
         acked_header: AckedPacketHeader,
         packet_data: &mut PacketData,
-        config: &Arc<NetworkConfig>,
+        config: Arc<NetworkConfig>,
     ) -> NetworkResult<()> {
         let payload_length = payload.len() as u16;
         let num_fragments =

--- a/src/net/connection/connection_pool.rs
+++ b/src/net/connection/connection_pool.rs
@@ -36,8 +36,7 @@ impl ConnectionPool {
                 Some(connection) => Ok(connection.clone()),
                 None => Err(NetworkErrorKind::ConnectionPoolError(String::from(
                     "Could not get connection from connection pool",
-                ))
-                .into()),
+                )).into()),
             }
         } else {
             drop(lock);
@@ -102,8 +101,7 @@ impl ConnectionPool {
                 return Err(NetworkErrorKind::PoisonedLock(format!(
                     "Error when checking for timed out connections: {:?}",
                     e
-                ))
-                .into());
+                )).into());
             }
         }
 

--- a/src/net/connection/quality.rs
+++ b/src/net/connection/quality.rs
@@ -20,10 +20,8 @@ pub struct RttMeasurer {
 
 impl RttMeasurer {
     /// Creates and returns a new RttMeasurer
-    pub fn new(config: &Arc<NetworkConfig>) -> RttMeasurer {
-        RttMeasurer {
-            config: config.clone(),
-        }
+    pub fn new(config: Arc<NetworkConfig>) -> RttMeasurer {
+        RttMeasurer { config }
     }
 
     /// This will calculate the round trip time (rtt) from the given acknowledgement.
@@ -87,12 +85,12 @@ mod test {
             .to_socket_addrs()
             .unwrap();
         let _new_conn =
-            VirtualConnection::new(addr.next().unwrap(), &Arc::new(NetworkConfig::default()));
+            VirtualConnection::new(addr.next().unwrap(), Arc::new(NetworkConfig::default()));
     }
 
     #[test]
     fn convert_duration_to_milliseconds_test() {
-        let network_quality = RttMeasurer::new(&Arc::new(NetworkConfig::default()));
+        let network_quality = RttMeasurer::new(Arc::new(NetworkConfig::default()));
         let milliseconds1 = network_quality.as_milliseconds(Duration::from_secs(1));
         let milliseconds2 = network_quality.as_milliseconds(Duration::from_millis(1500));
         let milliseconds3 = network_quality.as_milliseconds(Duration::from_millis(1671));
@@ -109,7 +107,7 @@ mod test {
         config.rtt_smoothing_factor = 0.10;
         config.rtt_max_value = 250;
 
-        let network_quality = RttMeasurer::new(&Arc::new(config));
+        let network_quality = RttMeasurer::new(Arc::new(config));
         let smoothed_rtt = network_quality.smooth_out_rtt(300);
 
         // 300ms has exceeded 50ms over the max allowed rtt. So we check if or smoothing factor is now 10% from 50.

--- a/src/net/connection/timeout_thread.rs
+++ b/src/net/connection/timeout_thread.rs
@@ -31,7 +31,7 @@ pub struct TimeoutThread {
 impl TimeoutThread {
     pub fn new(
         events_sender: Sender<Event>,
-        connection_pool: &Arc<ConnectionPool>,
+        connection_pool: Arc<ConnectionPool>,
     ) -> TimeoutThread {
         let poll_interval = Duration::from_secs(TIMEOUT_POLL_INTERVAL);
 
@@ -40,7 +40,7 @@ impl TimeoutThread {
             poll_interval,
             timeout_check_thread: None,
             sender: events_sender,
-            connection_pool: connection_pool.clone(),
+            connection_pool,
         }
     }
 

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -28,18 +28,18 @@ impl UdpSocket {
     pub fn bind<A: ToSocketAddrs>(addr: A, config: NetworkConfig) -> NetworkResult<Self> {
         let socket = net::UdpSocket::bind(addr)?;
 
-        let config = &Arc::new(config);
+        let config = Arc::new(config);
         let (tx, rx) = mpsc::channel();
 
-        let connection_pool = Arc::new(ConnectionPool::new(config));
+        let connection_pool = Arc::new(ConnectionPool::new(config.clone()));
 
-        let mut timeout_thread = TimeoutThread::new(tx.clone(), &connection_pool);
+        let mut timeout_thread = TimeoutThread::new(tx.clone(), connection_pool.clone());
         let timeout_error_channel = timeout_thread.start()?;
 
         Ok(UdpSocket {
             socket,
             recv_buffer: vec![0; config.receive_buffer_max_size],
-            _config: config.clone(),
+            _config: config,
             link_conditioner: None,
             connections: connection_pool,
             _timeout_thread: timeout_thread,


### PR DESCRIPTION
This gives some control back to the callers of these methods in terms of whether or not the Arc should be cloned.