### PR TITLE
Move bincode and serve to dev-dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,20 +21,20 @@ autobenches = false
 travis-ci = { repository = "amethyst/laminar", branch = "master" }
 
 [dependencies]
-serde = "1.0"
-serde_derive = "1.0"
-bincode = "1.0"
-byteorder = "1.2.6"
+byteorder = "1.2"
 log = "0.4"
 failure = "0.1"
 failure_derive = "0.1"
 crc = "1.8"
-lazy_static = "1.1.0"
+lazy_static = "1.1"
 rand = "0.5"
 clap = { version = "2.32", features = ["yaml"], optional = true }
-env_logger = { version = "0.5.13", optional = true }
+env_logger = { version = "0.5", optional = true }
 
 [dev-dependencies]
+bincode = "1.0"
+serde = "1.0"
+serde_derive = "1.0"
 criterion = "0.2"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,20 +22,20 @@ travis-ci = { repository = "amethyst/laminar", branch = "master" }
 
 [dependencies]
 byteorder = "1.2"
-log = "0.4"
+crc = "1.8"
 failure = "0.1"
 failure_derive = "0.1"
-crc = "1.8"
 lazy_static = "1.1"
+log = "0.4"
 rand = "0.5"
 clap = { version = "2.32", features = ["yaml"], optional = true }
 env_logger = { version = "0.5", optional = true }
 
 [dev-dependencies]
 bincode = "1.0"
+criterion = "0.2"
 serde = "1.0"
 serde_derive = "1.0"
-criterion = "0.2"
 
 [features]
 tester = [


### PR DESCRIPTION
Move the bincode and serde dependencies to dev-dependencies since these are only used in the examples. I also updated the version specs to only specify the major.minor version to be consistent.