### PR TITLE
Make 'recv()' function take an immutable reference to`self`

### DIFF
--- a/examples/server_client.rs
+++ b/examples/server_client.rs
@@ -11,7 +11,7 @@ use laminar::{config::NetworkConfig, error::Result, net::UdpSocket, Packet};
 const SERVER: &str = "localhost:12351";
 
 fn server() -> Result<()> {
-    let mut socket = UdpSocket::bind(SERVER, NetworkConfig::default())?;
+    let socket = UdpSocket::bind(SERVER, NetworkConfig::default())?;
 
     println!("Listening for connections to {}", SERVER);
 
@@ -42,7 +42,7 @@ fn server() -> Result<()> {
 }
 
 fn client() -> Result<()> {
-    let mut socket = UdpSocket::bind("localhost:12352", NetworkConfig::default())?;
+    let socket = UdpSocket::bind("localhost:12352", NetworkConfig::default())?;
 
     let server = SERVER.parse()?;
 

--- a/src/bin/laminar-tester.rs
+++ b/src/bin/laminar-tester.rs
@@ -71,7 +71,7 @@ fn process_client_subcommand(m: &clap::ArgMatches<'_>) {
 
 fn run_server(socket_addr: &str) {
     let network_config = config::NetworkConfig::default();
-    let mut udp_server = net::UdpSocket::bind(socket_addr, network_config).unwrap();
+    let udp_server = net::UdpSocket::bind(socket_addr, network_config).unwrap();
     let mut packet_throughput = 0;
     let mut packets_total_received = 0;
     let mut second_counter = Instant::now();

--- a/src/error/network_error.rs
+++ b/src/error/network_error.rs
@@ -100,7 +100,12 @@ impl NetworkError {
         self.inner.get_context()
     }
 
-    /// Generate an `NetworkErrorKind` for poisoned connection.
+    /// Generate a `NetworkErrorKind` for a poisoned lock on the receive buffer
+    pub fn poisoned_lock(msg: &str) -> NetworkErrorKind {
+        NetworkErrorKind::PoisonedLock(msg.to_owned())
+    }
+
+    /// Generate a `NetworkErrorKind` for poisoned connection.
     pub fn poisoned_connection_error(msg: &str) -> NetworkErrorKind {
         NetworkErrorKind::FailedToAddConnection(msg.to_owned())
     }

--- a/src/net/connection/connection_pool.rs
+++ b/src/net/connection/connection_pool.rs
@@ -36,7 +36,8 @@ impl ConnectionPool {
                 Some(connection) => Ok(connection.clone()),
                 None => Err(NetworkErrorKind::ConnectionPoolError(String::from(
                     "Could not get connection from connection pool",
-                )).into()),
+                ))
+                .into()),
             }
         } else {
             drop(lock);
@@ -101,7 +102,8 @@ impl ConnectionPool {
                 return Err(NetworkErrorKind::PoisonedLock(format!(
                     "Error when checking for timed out connections: {:?}",
                     e
-                )).into());
+                ))
+                .into());
             }
         }
 

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -51,7 +51,9 @@ impl UdpSocket {
 
     /// Receives a single datagram message on the socket. On success, returns the packet containing origin and data.
     pub fn recv(&self) -> NetworkResult<Option<Packet>> {
-        let (len, addr) = self.socket.recv_from(self.recv_buffer.borrow_mut().as_mut())?;
+        let (len, addr) = self
+            .socket
+            .recv_from(self.recv_buffer.borrow_mut().as_mut())?;
 
         if len > 0 {
             let packet = &self.recv_buffer.borrow()[..len];

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -7,6 +7,7 @@ use events::Event;
 use net::link_conditioner::LinkConditioner;
 use packet::Packet;
 
+use std::cell::RefCell;
 use std::error::Error;
 use std::sync::mpsc::{self, Receiver, Sender};
 use std::sync::Arc;
@@ -14,7 +15,7 @@ use std::sync::Arc;
 /// Represents an <ip>:<port> combination listening for UDP traffic
 pub struct UdpSocket {
     socket: net::UdpSocket,
-    recv_buffer: Vec<u8>,
+    recv_buffer: RefCell<Vec<u8>>,
     _config: Arc<NetworkConfig>,
     link_conditioner: Option<LinkConditioner>,
     _timeout_thread: TimeoutThread,
@@ -38,7 +39,7 @@ impl UdpSocket {
 
         Ok(UdpSocket {
             socket,
-            recv_buffer: vec![0; config.receive_buffer_max_size],
+            recv_buffer: RefCell::new(vec![0; config.receive_buffer_max_size]),
             _config: config,
             link_conditioner: None,
             connections: connection_pool,
@@ -49,11 +50,11 @@ impl UdpSocket {
     }
 
     /// Receives a single datagram message on the socket. On success, returns the packet containing origin and data.
-    pub fn recv(&mut self) -> NetworkResult<Option<Packet>> {
-        let (len, addr) = self.socket.recv_from(&mut self.recv_buffer)?;
+    pub fn recv(&self) -> NetworkResult<Option<Packet>> {
+        let (len, addr) = self.socket.recv_from(self.recv_buffer.borrow_mut().as_mut())?;
 
         if len > 0 {
-            let packet = &self.recv_buffer[..len];
+            let packet = &self.recv_buffer.borrow()[..len];
 
             if let Ok(error) = self.timeout_error_channel.try_recv() {
                 // we could recover from error here.

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -58,7 +58,10 @@ impl UdpSocket {
         )?;
 
         if len > 0 {
-            let packet = &self.recv_buffer.read()?[..len];
+            let packet = &self
+                .recv_buffer
+                .read()
+                .map_err(|error| NetworkError::poisoned_lock(error.description()))?[..len];
 
             if let Ok(error) = self.timeout_error_channel.try_recv() {
                 // we could recover from error here.


### PR DESCRIPTION
Allow the caller to receive data on the socket without owning a mut reference. Addresses https://github.com/amethyst/laminar/issues/115.
Since the socket's `recv_buffer` is owned and only written to by the `recv()` method, we can use `Mutex` to provide that mutability.