### PR TITLE
Fixed buffer bug

### DIFF
--- a/src/net/socket.rs
+++ b/src/net/socket.rs
@@ -159,30 +159,49 @@ impl Socket {
 
 #[cfg(test)]
 mod tests {
-    use crate::{Socket, Packet, Config};
+    use crate::{Config, Packet, Socket};
     use std::net::SocketAddr;
     use std::thread;
 
     #[test]
     fn test_send_receive() {
-        let (mut server, _, packet_receiver) = Socket::bind("127.0.0.1:12345".parse::<SocketAddr>().unwrap(), Config::default()).unwrap();
-        let (mut client, packet_sender, _) = Socket::bind("127.0.0.1:12344".parse::<SocketAddr>().unwrap(), Config::default()).unwrap();
+        let (mut server, _, packet_receiver) = Socket::bind(
+            "127.0.0.1:12345".parse::<SocketAddr>().unwrap(),
+            Config::default(),
+        )
+        .unwrap();
+        let (mut client, packet_sender, _) = Socket::bind(
+            "127.0.0.1:12344".parse::<SocketAddr>().unwrap(),
+            Config::default(),
+        )
+        .unwrap();
 
         thread::spawn(move || client.start_polling());
         thread::spawn(move || server.start_polling());
 
-        packet_sender.send(Packet::unreliable("127.0.0.1:12345".parse::<SocketAddr>().unwrap(), vec![1, 2, 3, 4, 5, 6, 7, 8, 9])).unwrap();
-        packet_sender.send(Packet::unreliable("127.0.0.1:12345".parse::<SocketAddr>().unwrap(), vec![1, 2, 3, 4, 5, 6, 7, 8, 9])).unwrap();
-        packet_sender.send(Packet::unreliable("127.0.0.1:12345".parse::<SocketAddr>().unwrap(), vec![1, 2, 3, 4, 5, 6, 7, 8, 9])).unwrap();
+        packet_sender
+            .send(Packet::unreliable(
+                "127.0.0.1:12345".parse::<SocketAddr>().unwrap(),
+                vec![1, 2, 3, 4, 5, 6, 7, 8, 9],
+            ))
+            .unwrap();
+        packet_sender
+            .send(Packet::unreliable(
+                "127.0.0.1:12345".parse::<SocketAddr>().unwrap(),
+                vec![1, 2, 3, 4, 5, 6, 7, 8, 9],
+            ))
+            .unwrap();
+        packet_sender
+            .send(Packet::unreliable(
+                "127.0.0.1:12345".parse::<SocketAddr>().unwrap(),
+                vec![1, 2, 3, 4, 5, 6, 7, 8, 9],
+            ))
+            .unwrap();
 
         let mut iter = packet_receiver.iter();
 
         assert!(iter.next().is_some());
         assert!(iter.next().is_some());
         assert!(iter.next().is_some());
-    }
-
-    pub fn payload() -> Vec<u8> {
-        vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
     }
 }

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,11 +1,11 @@
 use laminar::{Config, DeliveryMethod, Packet, Socket, SocketEvent};
+use log::{debug, error};
 use std::{
     net::SocketAddr,
     sync::mpsc::Receiver,
     thread::{self, JoinHandle},
     time::{Duration, Instant},
 };
-use log::{error, debug};
 
 /// This is an test server we use to receive data from clients.
 pub struct ServerMoq {
@@ -40,7 +40,7 @@ impl ServerMoq {
                         packets_total_received += 1;
                         packet_throughput += 1;
                         packet_sender.send(packet).unwrap();
-                    },
+                    }
                     _ => {
                         debug!("Received unexpected event");
                     }
@@ -52,7 +52,7 @@ impl ServerMoq {
                         if cancelled {
                             return packets_total_received;
                         }
-                    },
+                    }
                     Err(e) => {
                         error!("Received error on cancelleation channel: {:?}", e);
                     }

--- a/tests/fragments.rs
+++ b/tests/fragments.rs
@@ -47,7 +47,7 @@ pub fn fragment_packet_integration_test() {
             debug!("Server stopped");
             let _total_received = server_thread.join().unwrap();
             let _elapsed_time = stopwatch.elapsed();
-        },
+        }
         Err(e) => {
             error!("Error sending cancellation message: {:?}", e);
         }


### PR DESCRIPTION
I encountered a bug that I had encountered before. It is about the receive buffer. I can remember some discussion about that and we decided to change it back to a dynamic vector. However this won't work as described on [this page](https://stackoverflow.com/questions/26778657/rust-udpsocket-recv-from-fails-with-end-of-file-but-i-can-see-the-incoming-pa). 

I added a unit tests which was first failing but worked after the fix. 