### PR TITLE
Write + read headers properly for reliable packets

### DIFF
--- a/examples/udp.rs
+++ b/examples/udp.rs
@@ -4,9 +4,9 @@
 //! 3. constructing the packet for sending.
 use laminar::{Config, Packet, Socket, SocketEvent};
 
+use crossbeam_channel::Sender;
 use std::net::SocketAddr;
 use std::thread;
-use crossbeam_channel::Sender;
 
 /// The socket address of where the server is located.
 const SERVER_ADDR: &'static str = "127.0.0.1:12345";
@@ -46,12 +46,9 @@ pub fn receive_data() {
                 let received_data: &[u8] = packet.payload();
 
                 // you can here deserialize your bytes into the data you have passed it when sending.
-                println!(
-                    "Received {}",
-                    count
-                );
+                println!("Received {}", count);
 
-                count+=1;
+                count += 1;
             }
             Ok(_) => {}
             Err(e) => {
@@ -77,7 +74,6 @@ pub fn construct_packet() -> Packet {
 
 // TODO: Use functions in example
 fn main() {
-
     let handle = thread::spawn(move || {
         receive_data();
     });

--- a/src/infrastructure.rs
+++ b/src/infrastructure.rs
@@ -10,6 +10,7 @@ mod local_ack;
 pub mod arranging;
 
 pub use self::acknowlegement::AcknowledgementHandler;
+pub use self::acknowlegement::WaitingPacket;
 pub use self::congestion::CongestionHandler;
 pub use self::external_ack::ExternalAcks;
 pub use self::fragmenter::Fragmentation;

--- a/src/infrastructure/acknowlegement.rs
+++ b/src/infrastructure/acknowlegement.rs
@@ -39,7 +39,8 @@ impl AcknowledgementHandler {
         self.their_acks.ack(incoming_seq);
 
         let dropped_packets = self.waiting_packets.ack(incoming_seq, self.bit_mask());
-        self.dropped_packets.extend(dropped_packets.into_iter().map(|(_, p)| p));
+        self.dropped_packets
+            .extend(dropped_packets.into_iter().map(|(_, p)| p));
     }
 
     /// Enqueue the outgoing packet for acknowledgement.

--- a/src/infrastructure/acknowlegement.rs
+++ b/src/infrastructure/acknowlegement.rs
@@ -88,20 +88,22 @@ mod test {
     fn acking_500_packets_with_packet_drop() {
         let mut handler = AcknowledgementHandler::new();
 
-        let mut count = 0;
+        let mut drop_count = 0;
 
-        for i in 0..500 {
+        for i in 0..100 {
+            handler.process_outgoing(vec![1, 2, 3].as_slice());
             handler.seq_num = i;
-            handler.process_outgoing(vec![i as u8, 2, 3].as_slice());
 
-            if i % 4 != 0 {
-                handler.process_incoming(i);
+            // dropping every 4th with modulo's
+            if i % 4 == 0 {
+                println!("Dropping packet: {}", drop_count);
+                drop_count += 1;
             } else {
-                count += 1;
+                handler.process_incoming(i);
             }
         }
 
-        assert_eq!(handler.dropped_packets.len(), count);
+        assert_eq!(handler.dropped_packets.len(), 25);
     }
 
     #[test]

--- a/src/infrastructure/acknowlegement.rs
+++ b/src/infrastructure/acknowlegement.rs
@@ -90,19 +90,18 @@ mod test {
 
         let mut count = 0;
 
-        for i in 0..200 {
+        for i in 0..500 {
             handler.seq_num = i;
-            handler.process_outgoing(vec![1, 2, 3].as_slice());
+            handler.process_outgoing(vec![i as u8, 2, 3].as_slice());
 
             if i % 4 != 0 {
                 handler.process_incoming(i);
-            }else {
+            } else {
                 count += 1;
             }
         }
 
-        println!("{}", count);
-        assert_eq!(handler.dropped_packets.len(), 25);
+        assert_eq!(handler.dropped_packets.len(), count);
     }
 
     #[test]

--- a/src/infrastructure/acknowlegement.rs
+++ b/src/infrastructure/acknowlegement.rs
@@ -45,7 +45,6 @@ impl AcknowledgementHandler {
 
     /// Enqueue the outgoing packet for acknowledgement.
     pub fn process_outgoing(&mut self, payload: &[u8]) {
-        println!("Dropped packets are: {:#?}", self.dropped_packets);
         self.waiting_packets.enqueue(self.seq_num, &payload);
     }
 }

--- a/src/infrastructure/external_ack.rs
+++ b/src/infrastructure/external_ack.rs
@@ -17,6 +17,7 @@ impl ExternalAcks {
     /// Acks a packet
     pub fn ack(&mut self, seq_num: u16) {
         if !self.initialized {
+//            println!("ExternalAcks is not initialized. Initializing with: {:#?}", seq_num);
             self.last_seq = seq_num;
             self.initialized = true;
             return;
@@ -25,6 +26,7 @@ impl ExternalAcks {
         let pos_diff = seq_num.wrapping_sub(self.last_seq);
         let neg_diff = self.last_seq.wrapping_sub(seq_num);
 
+//        println!("Pos_diff is: {:#?}, Neg_diff is: {:#?}", pos_diff, neg_diff);
         if pos_diff == 0 {
             return;
         }
@@ -32,6 +34,7 @@ impl ExternalAcks {
         if pos_diff < 32000 {
             if pos_diff <= 32 {
                 self.field = ((self.field << 1) | 1) << (pos_diff - 1);
+//                println!("pos_diff is less than 32. Field is: {:#?}", self.field);
             } else {
                 self.field = 0;
             }

--- a/src/infrastructure/external_ack.rs
+++ b/src/infrastructure/external_ack.rs
@@ -68,7 +68,7 @@ mod test {
         acks.ack(2);
 
         assert_eq!(acks.last_seq, 2);
-        assert_eq!(acks.field, 0b11);
+        assert_eq!(acks.field, 1 | (1 << 1));
     }
 
     #[test]
@@ -79,7 +79,7 @@ mod test {
         acks.ack(2);
 
         assert_eq!(acks.last_seq, 2);
-        assert_eq!(acks.field, 0b11);
+        assert_eq!(acks.field, 1 | (1 << 1));
     }
 
     #[test]
@@ -184,6 +184,14 @@ mod test {
         acks.ack(6);
         acks.ack(4);
         assert_eq!(acks.last_seq, 6);
-        assert_eq!(acks.field, 0b110010);
+        assert_eq!(
+            acks.field,
+            0        | // 5 (missing)
+                       (1 << 1) | // 4 (present)
+                       (0 << 2) | // 3 (missing)
+                       (0 << 3) | // 2 (missing)
+                       (1 << 4) | // 1 (present)
+                       (1 << 5) // 0 (present)
+        );
     }
 }

--- a/src/infrastructure/external_ack.rs
+++ b/src/infrastructure/external_ack.rs
@@ -17,7 +17,6 @@ impl ExternalAcks {
     /// Acks a packet
     pub fn ack(&mut self, seq_num: u16) {
         if !self.initialized {
-            // println!("ExternalAcks is not initialized. Initializing with: {:#?}", seq_num);
             self.last_seq = seq_num;
             self.initialized = true;
             return;
@@ -26,7 +25,6 @@ impl ExternalAcks {
         let pos_diff = seq_num.wrapping_sub(self.last_seq);
         let neg_diff = self.last_seq.wrapping_sub(seq_num);
 
-        // println!("Pos_diff is: {:#?}, Neg_diff is: {:#?}", pos_diff, neg_diff);
         if pos_diff == 0 {
             return;
         }
@@ -34,7 +32,6 @@ impl ExternalAcks {
         if pos_diff < 32000 {
             if pos_diff <= 32 {
                 self.field = ((self.field << 1) | 1) << (pos_diff - 1);
-            // println!("pos_diff is less than 32. Field is: {:#?}", self.field);
             } else {
                 self.field = 0;
             }

--- a/src/infrastructure/external_ack.rs
+++ b/src/infrastructure/external_ack.rs
@@ -17,7 +17,7 @@ impl ExternalAcks {
     /// Acks a packet
     pub fn ack(&mut self, seq_num: u16) {
         if !self.initialized {
-//            println!("ExternalAcks is not initialized. Initializing with: {:#?}", seq_num);
+            // println!("ExternalAcks is not initialized. Initializing with: {:#?}", seq_num);
             self.last_seq = seq_num;
             self.initialized = true;
             return;
@@ -26,7 +26,7 @@ impl ExternalAcks {
         let pos_diff = seq_num.wrapping_sub(self.last_seq);
         let neg_diff = self.last_seq.wrapping_sub(seq_num);
 
-//        println!("Pos_diff is: {:#?}, Neg_diff is: {:#?}", pos_diff, neg_diff);
+        // println!("Pos_diff is: {:#?}, Neg_diff is: {:#?}", pos_diff, neg_diff);
         if pos_diff == 0 {
             return;
         }
@@ -34,7 +34,7 @@ impl ExternalAcks {
         if pos_diff < 32000 {
             if pos_diff <= 32 {
                 self.field = ((self.field << 1) | 1) << (pos_diff - 1);
-//                println!("pos_diff is less than 32. Field is: {:#?}", self.field);
+            // println!("pos_diff is less than 32. Field is: {:#?}", self.field);
             } else {
                 self.field = 0;
             }

--- a/src/infrastructure/local_ack.rs
+++ b/src/infrastructure/local_ack.rs
@@ -36,21 +36,30 @@ impl LocalAckRecord {
         let mut acked_packets = Vec::new();
 
         for key in self.packets.keys() {
-//            println!("Checking {:#?}", key);
+            // println!("Checking {:#?}", key);
             let diff = seq.wrapping_sub(*key);
             if diff == 0 {
-//                println!("Acking packet {:#?}", key);
+                // This packet (ack)
+                // println!("Acking packet {:#?}", key);
                 acked_packets.push(*key);
             } else if diff <= 32 {
+                // seq > key, so it's old packet
+                // within last 32 so checkable within bitfield
                 let field_acked = (seq_field & (1 << (diff - 1)) != 0);
                 if field_acked {
                     acked_packets.push(*key);
+                } else {
+                    dropped_packets.push(*key);
                 }
-//                println!("Field_acked is: {:#?}", field_acked);
+                // println!("Field_acked is: {:#?}", field_acked);
             } else if diff < 32000 {
-//                println!("Adding a dropped packet: {:#?}", key);
+                // Old packet that's not within 32, so can't be acked
+                // ASSUME DROPPED
+                // println!("dropping old packet: {:#?}", key);
                 dropped_packets.push(*key);
             }
+            // otherwise, wrapped around, so key > seq (new)
+            // New packet (don't drop or ack)
         }
 
         for seq_number in &acked_packets {
@@ -127,7 +136,7 @@ mod test {
         let dropped = record.ack(16, !0);
 
         assert_eq!(dropped.len(), 0);
-        assert!(record.is_empty());
+        assert_eq!(record.len(), 0);
     }
 
     #[test]

--- a/src/infrastructure/local_ack.rs
+++ b/src/infrastructure/local_ack.rs
@@ -36,15 +36,19 @@ impl LocalAckRecord {
         let mut acked_packets = Vec::new();
 
         for key in self.packets.keys() {
+//            println!("Checking {:#?}", key);
             let diff = seq.wrapping_sub(*key);
             if diff == 0 {
+//                println!("Acking packet {:#?}", key);
                 acked_packets.push(*key);
             } else if diff <= 32 {
                 let field_acked = (seq_field & (1 << (diff - 1)) != 0);
                 if field_acked {
                     acked_packets.push(*key);
                 }
+//                println!("Field_acked is: {:#?}", field_acked);
             } else if diff < 32000 {
+//                println!("Adding a dropped packet: {:#?}", key);
                 dropped_packets.push(*key);
             }
         }

--- a/src/infrastructure/local_ack.rs
+++ b/src/infrastructure/local_ack.rs
@@ -46,12 +46,12 @@ impl LocalAckRecord {
                 // seq > key, so it's old packet
                 // within last 32 so checkable within bitfield
                 let field_acked = (seq_field & (1 << (diff - 1)) != 0);
+                // println!("Field_acked is: {:#?}", field_acked);
                 if field_acked {
                     acked_packets.push(*key);
                 } else {
                     dropped_packets.push(*key);
                 }
-                // println!("Field_acked is: {:#?}", field_acked);
             } else if diff < 32000 {
                 // Old packet that's not within 32, so can't be acked
                 // ASSUME DROPPED

--- a/src/infrastructure/local_ack.rs
+++ b/src/infrastructure/local_ack.rs
@@ -36,17 +36,14 @@ impl LocalAckRecord {
         let mut acked_packets = Vec::new();
 
         for key in self.packets.keys() {
-            // println!("Checking {:#?}", key);
             let diff = seq.wrapping_sub(*key);
             if diff == 0 {
                 // This packet (ack)
-                // println!("Acking packet {:#?}", key);
                 acked_packets.push(*key);
             } else if diff <= 32 {
                 // seq > key, so it's old packet
                 // within last 32 so checkable within bitfield
                 let field_acked = (seq_field & (1 << (diff - 1)) != 0);
-                // println!("Field_acked is: {:#?}", field_acked);
                 if field_acked {
                     acked_packets.push(*key);
                 } else {
@@ -55,7 +52,6 @@ impl LocalAckRecord {
             } else if diff < 32000 {
                 // Old packet that's not within 32, so can't be acked
                 // ASSUME DROPPED
-                // println!("dropping old packet: {:#?}", key);
                 dropped_packets.push(*key);
             }
             // otherwise, wrapped around, so key > seq (new)

--- a/src/net/socket.rs
+++ b/src/net/socket.rs
@@ -131,13 +131,13 @@ impl Socket {
             }
 
             for payload in dropped_packets {
-                bytes_sent += self.send_packet(&packet.addr(), &payload)?;
+                bytes_sent += self.send_to(Packet::new(packet.addr(), payload, packet.delivery_guarantee(), packet.order_guarantee()))?;
             }
 
-            return Ok(bytes_sent);
+            Ok(bytes_sent)
+        } else {
+            Ok(0)
         }
-
-        Ok(0)
     }
 
     // On success the packet will be send on the `event_sender`

--- a/src/net/socket.rs
+++ b/src/net/socket.rs
@@ -131,7 +131,12 @@ impl Socket {
             }
 
             for payload in dropped_packets {
-                bytes_sent += self.send_to(Packet::new(packet.addr(), payload, packet.delivery_guarantee(), packet.order_guarantee()))?;
+                bytes_sent += self.send_to(Packet::new(
+                    packet.addr(),
+                    payload,
+                    packet.delivery_guarantee(),
+                    packet.order_guarantee(),
+                ))?;
             }
 
             Ok(bytes_sent)

--- a/src/net/virtual_connection.rs
+++ b/src/net/virtual_connection.rs
@@ -3,7 +3,7 @@ use crate::{
     error::{ErrorKind, PacketErrorKind, Result},
     infrastructure::{
         arranging::{Arranging, ArrangingSystem, OrderingSystem, SequencingSystem},
-        AcknowledgementHandler, CongestionHandler, Fragmentation,
+        AcknowledgementHandler, CongestionHandler, Fragmentation, WaitingPacket,
     },
     net::constants::{
         ACKED_PACKET_HEADER, DEFAULT_ORDERING_STREAM, DEFAULT_SEQUENCING_STREAM,
@@ -174,7 +174,8 @@ impl VirtualConnection {
 
                 self.congestion_handler
                     .process_outgoing(self.acknowledge_handler.seq_num);
-                self.acknowledge_handler.process_outgoing(payload);
+                self.acknowledge_handler
+                    .process_outgoing(payload, ordering_guarantee);
 
                 self.acknowledge_handler.seq_num = self.acknowledge_handler.seq_num.wrapping_add(1);
 
@@ -370,7 +371,7 @@ impl VirtualConnection {
     /// This will gather dropped packets from the reliable channels.
     ///
     /// Note that after requesting dropped packets the dropped packets will be removed from this client.
-    pub fn gather_dropped_packets(&mut self) -> Vec<Box<[u8]>> {
+    pub fn gather_dropped_packets(&mut self) -> Vec<WaitingPacket> {
         self.acknowledge_handler.dropped_packets.drain(..).collect()
     }
 }

--- a/src/net/virtual_connection.rs
+++ b/src/net/virtual_connection.rs
@@ -260,7 +260,9 @@ impl VirtualConnection {
                             self.congestion_handler
                                 .process_incoming(acked_header.sequence());
                             self.acknowledge_handler
-                                .process_incoming(acked_header.sequence());
+                                .process_incoming(acked_header.sequence(),
+                                                 acked_header.ack_seq(),
+                                                 acked_header.ack_field());
                         }
                     }
                 } else {
@@ -337,7 +339,9 @@ impl VirtualConnection {
                     self.congestion_handler
                         .process_incoming(acked_header.sequence());
                     self.acknowledge_handler
-                        .process_incoming(acked_header.sequence());
+                        .process_incoming(acked_header.sequence(),
+                                         acked_header.ack_seq(),
+                                         acked_header.ack_field());
                 }
             }
         }

--- a/src/net/virtual_connection.rs
+++ b/src/net/virtual_connection.rs
@@ -259,10 +259,11 @@ impl VirtualConnection {
                         if let Some(acked_header) = acked_header {
                             self.congestion_handler
                                 .process_incoming(acked_header.sequence());
-                            self.acknowledge_handler
-                                .process_incoming(acked_header.sequence(),
-                                                 acked_header.ack_seq(),
-                                                 acked_header.ack_field());
+                            self.acknowledge_handler.process_incoming(
+                                acked_header.sequence(),
+                                acked_header.ack_seq(),
+                                acked_header.ack_field(),
+                            );
                         }
                     }
                 } else {
@@ -338,10 +339,11 @@ impl VirtualConnection {
 
                     self.congestion_handler
                         .process_incoming(acked_header.sequence());
-                    self.acknowledge_handler
-                        .process_incoming(acked_header.sequence(),
-                                         acked_header.ack_seq(),
-                                         acked_header.ack_field());
+                    self.acknowledge_handler.process_incoming(
+                        acked_header.sequence(),
+                        acked_header.ack_seq(),
+                        acked_header.ack_field(),
+                    );
                 }
             }
         }

--- a/src/packet/header/acked_packet_header.rs
+++ b/src/packet/header/acked_packet_header.rs
@@ -34,13 +34,11 @@ impl AckedPacketHeader {
     }
 
     /// Get bit field of all last 32 acknowledged packages
-    #[cfg(test)]
     pub fn ack_field(&self) -> u32 {
         self.ack_field
     }
 
     /// Get last acknowledged sequence number.
-    #[cfg(test)]
     pub fn ack_seq(&self) -> u16 {
         self.ack_seq
     }
@@ -92,6 +90,7 @@ mod tests {
         assert_eq!(buffer[1], 1);
         assert_eq!(buffer[3], 2);
         assert_eq!(buffer[7], 3);
+        assert_eq!(buffer.len() as u8, AckedPacketHeader::size());
     }
 
     #[test]


### PR DESCRIPTION
    There were two problems:
    
    1. New packets were sent without the necessary headers including an
    updated index
    2. Acknowledgement was reading *its own* headers, instead of the foreign
    headers in calculating dropped vs acknowledged packets

This PR includes #175 because it hasn't been merged yet :/ let me know if i need to rebase it but it'd be a lot of work for nothing since we need to merge both