### PR TITLE
Move time access to public boundaries

### DIFF
--- a/src/infrastructure/congestion.rs
+++ b/src/infrastructure/congestion.rs
@@ -35,9 +35,9 @@ impl CongestionHandler {
     ///
     /// This will insert an entry which is used for keeping track of the sending time.
     /// Once we process incoming sequence numbers we can calculate the `RTT` time.
-    pub fn process_outgoing(&mut self, seq: u16) {
+    pub fn process_outgoing(&mut self, seq: u16, time: Instant) {
         self.congestion_data
-            .insert(seq, CongestionData::new(seq, Instant::now()));
+            .insert(seq, CongestionData::new(seq, time));
     }
 }
 
@@ -45,12 +45,13 @@ impl CongestionHandler {
 mod test {
     use crate::infrastructure::CongestionHandler;
     use crate::Config;
+    use std::time::Instant;
 
     #[test]
     fn congestion_entry_created() {
         let mut congestion_handler = CongestionHandler::new(&Config::default());
 
-        congestion_handler.process_outgoing(1);
+        congestion_handler.process_outgoing(1, Instant::now());
 
         assert_eq!(congestion_handler.congestion_data.exists(1), true);
     }
@@ -60,7 +61,7 @@ mod test {
         let mut congestion_handler = CongestionHandler::new(&Config::default());
 
         assert_eq!(congestion_handler.rtt_measurer.get_rtt(), 0.);
-        congestion_handler.process_outgoing(1);
+        congestion_handler.process_outgoing(1, Instant::now());
         congestion_handler.process_incoming(1);
         assert_eq!(congestion_handler.rtt_measurer.get_rtt() != 0., true);
     }

--- a/src/net/connection.rs
+++ b/src/net/connection.rs
@@ -83,7 +83,7 @@ mod tests {
         // add 10 clients
         for i in 0..10 {
             connections.get_or_insert_connection(
-                format!("127.0.0.1:123{}", i).parse().unwrap(),
+                format!("127.0.0.1:122{}", i).parse().unwrap(),
                 &config,
                 now,
             );
@@ -97,7 +97,11 @@ mod tests {
             connections.idle_connections(wait, now + wait - Duration::from_nanos(1));
         assert_eq!(timed_out_connections.len(), 0);
 
+        #[cfg(not(windows))]
         let timed_out_connections = connections.idle_connections(wait, now + wait);
+        #[cfg(windows)]
+        let timed_out_connections =
+            connections.idle_connections(wait, now + wait + Duration::from_micros(1));
         assert_eq!(timed_out_connections.len(), 10);
     }
 

--- a/src/net/quality.rs
+++ b/src/net/quality.rs
@@ -82,7 +82,7 @@ mod test {
     use crate::config::Config;
     use crate::net::connection::VirtualConnection;
     use std::net::ToSocketAddrs;
-    use std::time::Duration;
+    use std::time::{Duration, Instant};
 
     static TEST_HOST_IP: &'static str = "127.0.0.1";
     static TEST_PORT: &'static str = "20000";
@@ -92,7 +92,8 @@ mod test {
         let mut addr = format!("{}:{}", TEST_HOST_IP, TEST_PORT)
             .to_socket_addrs()
             .unwrap();
-        let _new_conn = VirtualConnection::new(addr.next().unwrap(), &Config::default());
+        let _new_conn =
+            VirtualConnection::new(addr.next().unwrap(), &Config::default(), Instant::now());
     }
 
     #[test]

--- a/src/net/virtual_connection.rs
+++ b/src/net/virtual_connection.rs
@@ -40,9 +40,9 @@ pub struct VirtualConnection {
 
 impl VirtualConnection {
     /// Creates and returns a new Connection that wraps the provided socket address
-    pub fn new(addr: SocketAddr, config: &Config) -> VirtualConnection {
+    pub fn new(addr: SocketAddr, config: &Config, time: Instant) -> VirtualConnection {
         VirtualConnection {
-            last_heard: Instant::now(),
+            last_heard: time,
             remote_address: addr,
             ordering_system: OrderingSystem::new(),
             sequencing_system: SequencingSystem::new(),
@@ -53,10 +53,11 @@ impl VirtualConnection {
         }
     }
 
-    /// Returns a Duration representing the interval since we last heard from the client
-    pub fn last_heard(&self) -> Duration {
-        let now = Instant::now();
-        now.duration_since(self.last_heard)
+    /// Returns a [Duration] representing the interval since we last heard from the client
+    pub fn last_heard(&self, time: Instant) -> Duration {
+        // TODO: Replace with saturating_duration_since once it becomes stable.
+        // This function panics if the user supplies a time instant earlier than last_heard.
+        time.duration_since(self.last_heard)
     }
 
     /// This will pre-process the given buffer to be sent over the network.
@@ -65,6 +66,7 @@ impl VirtualConnection {
         payload: &'a [u8],
         delivery_guarantee: DeliveryGuarantee,
         ordering_guarantee: OrderingGuarantee,
+        time: Instant,
     ) -> Result<Outgoing<'a>> {
         match delivery_guarantee {
             DeliveryGuarantee::Unreliable => {
@@ -173,7 +175,7 @@ impl VirtualConnection {
                 };
 
                 self.congestion_handler
-                    .process_outgoing(self.acknowledge_handler.local_sequence_num());
+                    .process_outgoing(self.acknowledge_handler.local_sequence_num(), time);
                 self.acknowledge_handler
                     .process_outgoing(payload, ordering_guarantee);
 
@@ -187,8 +189,9 @@ impl VirtualConnection {
         &mut self,
         received_data: &[u8],
         sender: &Sender<SocketEvent>,
+        time: Instant,
     ) -> crate::Result<()> {
-        self.last_heard = Instant::now();
+        self.last_heard = time;
 
         let mut packet_reader = PacketReader::new(received_data);
 
@@ -397,6 +400,7 @@ mod tests {
     use byteorder::{BigEndian, WriteBytesExt};
     use crossbeam_channel::{unbounded, TryRecvError};
     use std::io::Write;
+    use std::time::Instant;
 
     const PAYLOAD: [u8; 4] = [1, 2, 3, 4];
 
@@ -423,6 +427,7 @@ mod tests {
                     .concat()
                     .as_slice(),
                 &tx,
+                Instant::now(),
             )
             .unwrap();
         assert!(rx.try_recv().is_err());
@@ -436,6 +441,7 @@ mod tests {
                 .concat()
                 .as_slice(),
                 &tx,
+                Instant::now(),
             )
             .unwrap();
         assert!(rx.try_recv().is_err());
@@ -449,6 +455,7 @@ mod tests {
                 .concat()
                 .as_slice(),
                 &tx,
+                Instant::now(),
             )
             .unwrap();
         assert!(rx.try_recv().is_err());
@@ -462,6 +469,7 @@ mod tests {
                 .concat()
                 .as_slice(),
                 &tx,
+                Instant::now(),
             )
             .unwrap();
 
@@ -489,6 +497,7 @@ mod tests {
                 &buffer,
                 DeliveryGuarantee::Reliable,
                 OrderingGuarantee::Ordered(None),
+                Instant::now(),
             )
             .unwrap();
 
@@ -511,6 +520,7 @@ mod tests {
                 &buffer,
                 DeliveryGuarantee::Unreliable,
                 OrderingGuarantee::None,
+                Instant::now(),
             )
             .unwrap();
 
@@ -519,6 +529,7 @@ mod tests {
                 &buffer,
                 DeliveryGuarantee::Unreliable,
                 OrderingGuarantee::Sequenced(None),
+                Instant::now(),
             )
             .unwrap();
 
@@ -527,6 +538,7 @@ mod tests {
                 &buffer,
                 DeliveryGuarantee::Reliable,
                 OrderingGuarantee::Ordered(None),
+                Instant::now(),
             )
             .unwrap();
 
@@ -535,6 +547,7 @@ mod tests {
                 &buffer,
                 DeliveryGuarantee::Reliable,
                 OrderingGuarantee::Sequenced(None),
+                Instant::now(),
             )
             .unwrap();
     }
@@ -717,7 +730,7 @@ mod tests {
 
     /// ======= helper functions =========
     fn create_virtual_connection() -> VirtualConnection {
-        VirtualConnection::new(get_fake_addr(), &Config::default())
+        VirtualConnection::new(get_fake_addr(), &Config::default(), Instant::now())
     }
 
     fn get_fake_addr() -> std::net::SocketAddr {
@@ -768,7 +781,9 @@ mod tests {
 
         let (tx, rx) = unbounded::<SocketEvent>();
 
-        connection.process_incoming(packet.as_slice(), &tx).unwrap();
+        connection
+            .process_incoming(packet.as_slice(), &tx, Instant::now())
+            .unwrap();
 
         let event = rx.try_recv();
 
@@ -799,7 +814,9 @@ mod tests {
 
         let (tx, rx) = unbounded::<SocketEvent>();
 
-        connection.process_incoming(packet.as_slice(), &tx).unwrap();
+        connection
+            .process_incoming(packet.as_slice(), &tx, Instant::now())
+            .unwrap();
 
         let event = rx.try_recv();
 
@@ -817,7 +834,7 @@ mod tests {
         let buffer = vec![1; 500];
 
         let outgoing = connection
-            .process_outgoing(&buffer, delivery, ordering)
+            .process_outgoing(&buffer, delivery, ordering, Instant::now())
             .unwrap();
 
         match outgoing {


### PR DESCRIPTION
NOTE: This series depends on the manual polling patch series, I'm not sure how else I could split these up. See https://github.com/amethyst/laminar/pull/191

Accessing `Instant::now()` from within makes this library difficult to
test, especially when testing another system together with this library
you want to be able to precisely control time.

This also prevents tests from being flaky (the test using sleep has been replaced with an exact nanosecond-granularity check).

Using the provided looping poll from socket will still use its own time
so it's backward-compatible.

Some other parts such as "throughput" still use Instant but that should
probably be swapped out for a provided time as well.
