### PR TITLE
[bugfix] Correctly store arranging numbers for ordered and sequenced packets

### DIFF
--- a/src/infrastructure/acknowledgment.rs
+++ b/src/infrastructure/acknowledgment.rs
@@ -90,12 +90,18 @@ impl AcknowledgmentHandler {
     }
 
     /// Enqueue the outgoing packet for acknowledgment.
-    pub fn process_outgoing(&mut self, payload: &[u8], ordering_guarantee: OrderingGuarantee) {
+    pub fn process_outgoing(
+        &mut self,
+        payload: &[u8],
+        ordering_guarantee: OrderingGuarantee,
+        item_identifier: Option<SequenceNumber>,
+    ) {
         self.sent_packets.insert(
             self.sequence_number,
             SentPacket {
                 payload: Box::from(payload),
                 ordering_guarantee,
+                item_identifier,
             },
         );
 
@@ -127,6 +133,7 @@ impl AcknowledgmentHandler {
 pub struct SentPacket {
     pub payload: Box<[u8]>,
     pub ordering_guarantee: OrderingGuarantee,
+    pub item_identifier: Option<SequenceNumber>,
 }
 
 // TODO: At some point we should put something useful here. Possibly timing information or total
@@ -146,7 +153,7 @@ mod test {
         let mut handler = AcknowledgmentHandler::new();
         assert_eq!(handler.local_sequence_num(), 0);
         for i in 0..10 {
-            handler.process_outgoing(vec![].as_slice(), OrderingGuarantee::None);
+            handler.process_outgoing(vec![].as_slice(), OrderingGuarantee::None, None);
             assert_eq!(handler.local_sequence_num(), i + 1);
         }
     }
@@ -155,7 +162,7 @@ mod test {
     fn local_seq_num_wraps_on_overflow() {
         let mut handler = AcknowledgmentHandler::new();
         handler.sequence_number = u16::max_value();
-        handler.process_outgoing(vec![].as_slice(), OrderingGuarantee::None);
+        handler.process_outgoing(vec![].as_slice(), OrderingGuarantee::None, None);
         assert_eq!(handler.local_sequence_num(), 0);
     }
 
@@ -186,9 +193,9 @@ mod test {
         let mut handler = AcknowledgmentHandler::new();
 
         handler.sequence_number = 0;
-        handler.process_outgoing(vec![1, 2, 3].as_slice(), OrderingGuarantee::None);
+        handler.process_outgoing(vec![1, 2, 3].as_slice(), OrderingGuarantee::None, None);
         handler.sequence_number = 40;
-        handler.process_outgoing(vec![1, 2, 4].as_slice(), OrderingGuarantee::None);
+        handler.process_outgoing(vec![1, 2, 4].as_slice(), OrderingGuarantee::None, None);
 
         static ARBITRARY: u16 = 23;
         handler.process_incoming(ARBITRARY, 40, 0);
@@ -198,6 +205,7 @@ mod test {
             vec![SentPacket {
                 payload: vec![1, 2, 3].into_boxed_slice(),
                 ordering_guarantee: OrderingGuarantee::None,
+                item_identifier: None,
             }]
         );
     }
@@ -209,7 +217,7 @@ mod test {
 
         for i in 0..500 {
             handler.sequence_number = i;
-            handler.process_outgoing(vec![1, 2, 3].as_slice(), OrderingGuarantee::None);
+            handler.process_outgoing(vec![1, 2, 3].as_slice(), OrderingGuarantee::None, None);
 
             other.process_incoming(i, handler.remote_sequence_num(), handler.ack_bitfield());
             handler.process_incoming(i, other.remote_sequence_num(), other.ack_bitfield());
@@ -226,7 +234,7 @@ mod test {
         let mut drop_count = 0;
 
         for i in 0..100 {
-            handler.process_outgoing(vec![1, 2, 3].as_slice(), OrderingGuarantee::None);
+            handler.process_outgoing(vec![1, 2, 3].as_slice(), OrderingGuarantee::None, None);
             handler.sequence_number = i;
 
             // dropping every 4th with modulo's
@@ -273,7 +281,7 @@ mod test {
     #[test]
     fn test_process_outgoing() {
         let mut handler = AcknowledgmentHandler::new();
-        handler.process_outgoing(vec![1, 2, 3].as_slice(), OrderingGuarantee::None);
+        handler.process_outgoing(vec![1, 2, 3].as_slice(), OrderingGuarantee::None, None);
         assert_eq!(handler.sent_packets.len(), 1);
         assert_eq!(handler.local_sequence_num(), 1);
     }

--- a/src/net/connection.rs
+++ b/src/net/connection.rs
@@ -74,7 +74,7 @@ impl ActiveConnections {
 
     /// Returns the number of connected clients.
     #[cfg(test)]
-    pub fn count(&self) -> usize {
+    pub(crate) fn count(&self) -> usize {
         self.connections.len()
     }
 }

--- a/src/net/socket.rs
+++ b/src/net/socket.rs
@@ -247,12 +247,12 @@ impl Socket {
     }
 
     #[cfg(test)]
-    pub fn connection_count(&self) -> usize {
+    fn connection_count(&self) -> usize {
         self.connections.count()
     }
 
     #[cfg(test)]
-    pub fn forget_all_incoming_packets(&mut self) {
+    fn forget_all_incoming_packets(&mut self) {
         loop {
             match self.socket.recv_from(&mut self.recv_buffer) {
                 Ok((recv_len, _address)) => {

--- a/src/net/socket.rs
+++ b/src/net/socket.rs
@@ -157,6 +157,7 @@ impl Socket {
                     DeliveryGuarantee::Reliable,
                     // This is stored with the dropped packet because they could be mixed
                     waiting_packet.ordering_guarantee,
+                    waiting_packet.item_identifier,
                     time,
                 )
             })
@@ -166,6 +167,7 @@ impl Socket {
             packet.payload(),
             packet.delivery_guarantee(),
             packet.order_guarantee(),
+            None,
             time,
         )?;
 
@@ -377,6 +379,98 @@ mod tests {
     }
 
     #[test]
+    fn initial_sequenced_is_resent() {
+        let (mut server, server_sender, server_receiver) =
+            Socket::bind("127.0.0.1:12331".parse::<SocketAddr>().unwrap()).unwrap();
+        let (mut client, client_sender, client_receiver) =
+            Socket::bind("127.0.0.1:12332".parse::<SocketAddr>().unwrap()).unwrap();
+
+        let time = Instant::now();
+
+        // Send a packet that the server ignores/drops
+        client_sender
+            .send(Packet::reliable_sequenced(
+                "127.0.0.1:12331".parse::<SocketAddr>().unwrap(),
+                b"Do not arrive".iter().cloned().collect::<Vec<_>>(),
+                None,
+            ))
+            .unwrap();
+        client.manual_poll(time);
+
+        // Drop the inbound packet, this simulates a network error
+        server.forget_all_incoming_packets();
+
+        // Send a packet that the server receives
+        for id in 0..36 {
+            client_sender
+                .send(create_sequenced_packet(id, "127.0.0.1:12331"))
+                .unwrap();
+
+            server_sender
+                .send(create_sequenced_packet(id, "127.0.0.1:12332"))
+                .unwrap();
+
+            client.manual_poll(time);
+            server.manual_poll(time);
+
+            while let Ok(SocketEvent::Packet(pkt)) = server_receiver.try_recv() {
+                if pkt.payload() == b"Do not arrive" {
+                    return;
+                }
+            }
+            while let Ok(_) = client_receiver.try_recv() {}
+        }
+
+        panic!["Did not receive the ignored packet"];
+    }
+
+    #[test]
+    fn initial_ordered_is_resent() {
+        let (mut server, server_sender, server_receiver) =
+            Socket::bind("127.0.0.1:12333".parse::<SocketAddr>().unwrap()).unwrap();
+        let (mut client, client_sender, client_receiver) =
+            Socket::bind("127.0.0.1:12334".parse::<SocketAddr>().unwrap()).unwrap();
+
+        let time = Instant::now();
+
+        // Send a packet that the server ignores/drops
+        client_sender
+            .send(Packet::reliable_ordered(
+                "127.0.0.1:12333".parse::<SocketAddr>().unwrap(),
+                b"Do not arrive".iter().cloned().collect::<Vec<_>>(),
+                None,
+            ))
+            .unwrap();
+        client.manual_poll(time);
+
+        // Drop the inbound packet, this simulates a network error
+        server.forget_all_incoming_packets();
+
+        // Send a packet that the server receives
+        for id in 0..36 {
+            client_sender
+                .send(create_ordered_packet(id, "127.0.0.1:12333"))
+                .unwrap();
+
+            server_sender
+                .send(create_ordered_packet(id, "127.0.0.1:12334"))
+                .unwrap();
+
+            client.manual_poll(time);
+            server.manual_poll(time);
+
+            while let Ok(SocketEvent::Packet(pkt)) = server_receiver.try_recv() {
+                if pkt.payload() == b"Do not arrive" {
+                    return;
+                }
+            }
+            while let Ok(_) = client_receiver.try_recv() {}
+        }
+
+        panic!["Did not receive the ignored packet"];
+    }
+
+    #[test]
     fn manual_polling_socket() {
         let (mut server, _, packet_receiver) =
             Socket::bind("127.0.0.1:12339".parse::<SocketAddr>().unwrap()).unwrap();
@@ -555,6 +649,16 @@ mod tests {
     fn create_test_packet(id: u8, addr: &str) -> Packet {
         let payload = vec![id];
         Packet::reliable_unordered(addr.parse().unwrap(), payload)
+    }
+
+    fn create_ordered_packet(id: u8, addr: &str) -> Packet {
+        let payload = vec![id];
+        Packet::reliable_ordered(addr.parse().unwrap(), payload, None)
+    }
+
+    fn create_sequenced_packet(id: u8, addr: &str) -> Packet {
+        let payload = vec![id];
+        Packet::reliable_sequenced(addr.parse().unwrap(), payload, None)
     }
 
     #[test]


### PR DESCRIPTION
Previously, ordered packets would simply attain a new item identifier
from the stream generator if they were dropped. This patch ensures that
the not-yet-acked packets are stored with this value so that they use
that same value when they are re-sent.