### PR TITLE
[bugfix] Do not queue_packets twice when sequenced

### DIFF
--- a/src/net/virtual_connection.rs
+++ b/src/net/virtual_connection.rs
@@ -312,9 +312,7 @@ impl VirtualConnection {
                                 OrderingGuarantee::Sequenced(Some(arranging_header.stream_id())),
                             )?;
                         }
-                    }
-
-                    if let OrderingGuarantee::Ordered(_id) = header.ordering_guarantee() {
+                    } else if let OrderingGuarantee::Ordered(_id) = header.ordering_guarantee() {
                         let arranging_header = packet_reader.read_arranging_header(u16::from(
                             STANDARD_HEADER_SIZE + ACKED_PACKET_HEADER,
                         ))?;


### PR DESCRIPTION
Caused by a faulty if-else chain, the sequenced if would run, then the
ordered if would not run, causing its else to run, so packets became
queued twice.