### PR TITLE
Use a millisecond timeout to avoid mac test failures

### DIFF
--- a/src/net/socket.rs
+++ b/src/net/socket.rs
@@ -825,8 +825,8 @@ mod tests {
                 client.manual_poll(time);
                 server.manual_poll(time);
 
-                while let Ok(_) = client_receiver.try_recv() {}
-                while let Ok(event) = server_receiver.try_recv() {
+                while let Ok(_) = client_receiver.recv_timeout(Duration::from_millis(1)) {}
+                while let Ok(event) = server_receiver.recv_timeout(Duration::from_millis(1)) {
                     match event {
                         SocketEvent::Packet(pkt) => {
                             set.insert(pkt.payload()[0]);


### PR DESCRIPTION
Might work, or not, I don't have a mac to test on, but this is the only part that could fail I think. It could be that macOS uses an async kernel queue when sending a udp message.