### PR TITLE
Move the channels into Socket

### DIFF
--- a/examples/server_client.rs
+++ b/examples/server_client.rs
@@ -11,7 +11,7 @@ const SERVER: &str = "127.0.0.1:12351";
 
 fn server() -> Result<(), ErrorKind> {
     let mut socket = Socket::bind(SERVER)?;
-    let (mut sender, mut receiver) = (socket.get_sender(), socket.get_receiver());
+    let (mut sender, mut receiver) = (socket.get_packet_sender(), socket.get_event_receiver());
     let _thread = thread::spawn(move || socket.start_polling());
 
     loop {

--- a/examples/server_client.rs
+++ b/examples/server_client.rs
@@ -2,45 +2,43 @@
 //! Technically, they both work the same.
 //! Note that in practice you don't want to implement a chat client using UDP.
 use std::io::stdin;
+use std::thread;
+use std::time::Instant;
 
 use laminar::{ErrorKind, Packet, Socket, SocketEvent};
-use std::thread;
 
 const SERVER: &str = "127.0.0.1:12351";
 
-fn test() {}
-
 fn server() -> Result<(), ErrorKind> {
-    let (mut socket, packet_sender, event_receiver) = Socket::bind(SERVER)?;
+    let mut socket = Socket::bind(SERVER)?;
+    let (mut sender, mut receiver) = (socket.get_sender(), socket.get_receiver());
     let _thread = thread::spawn(move || socket.start_polling());
 
-    println!("Listening for connections to {}", SERVER);
-
     loop {
-        match event_receiver.recv().expect("Should get a message") {
-            SocketEvent::Packet(packet) => {
-                let msg = packet.payload();
+        if let Ok(event) = receiver.recv() {
+            match event {
+                SocketEvent::Packet(packet) => {
+                    let msg = packet.payload();
 
-                if msg == b"Bye!" {
-                    break;
-                }
+                    if msg == b"Bye!" {
+                        break;
+                    }
 
-                let msg = String::from_utf8_lossy(msg);
-                let ip = packet.addr().ip();
+                    let msg = String::from_utf8_lossy(msg);
+                    let ip = packet.addr().ip();
 
-                println!("Received {:?} from {:?}", msg, ip);
+                    println!("Received {:?} from {:?}", msg, ip);
 
-                packet_sender
-                    .send(Packet::reliable_unordered(
+                    sender.send(Packet::reliable_unordered(
                         packet.addr(),
                         "Copy that!".as_bytes().to_vec(),
-                    ))
-                    .unwrap();
+                    ));
+                }
+                SocketEvent::Timeout(address) => {
+                    println!("Client timed out: {}", address);
+                }
+                _ => {}
             }
-            SocketEvent::Timeout(address) => {
-                println!("Client timed out: {}", address);
-            }
-            _ => {}
         }
     }
 
@@ -49,9 +47,8 @@ fn server() -> Result<(), ErrorKind> {
 
 fn client() -> Result<(), ErrorKind> {
     let addr = "127.0.0.1:12352";
-    let (mut socket, packet_sender, event_receiver) = Socket::bind(addr)?;
+    let mut socket = Socket::bind(addr)?;
     println!("Connected on {}", addr);
-    let _thread = thread::spawn(move || socket.start_polling());
 
     let server = SERVER.parse().unwrap();
 
@@ -65,26 +62,26 @@ fn client() -> Result<(), ErrorKind> {
         stdin.read_line(&mut s_buffer)?;
         let line = s_buffer.replace(|x| x == '\n' || x == '\r', "");
 
-        packet_sender
-            .send(Packet::reliable_unordered(
-                server,
-                line.clone().into_bytes(),
-            ))
-            .unwrap();
+        socket.send(Packet::reliable_unordered(
+            server,
+            line.clone().into_bytes(),
+        ));
+
+        socket.manual_poll(Instant::now());
 
         if line == "Bye!" {
             break;
         }
 
-        match event_receiver.recv().unwrap() {
-            SocketEvent::Packet(packet) => {
+        match socket.recv() {
+            Some(SocketEvent::Packet(packet)) => {
                 if packet.addr() == server {
                     println!("Server sent: {}", String::from_utf8_lossy(packet.payload()));
                 } else {
                     println!("Unknown sender.");
                 }
             }
-            SocketEvent::Timeout(_) => {}
+            Some(SocketEvent::Timeout(_)) => {}
             _ => println!("Silence.."),
         }
     }

--- a/examples/simple_udp.rs
+++ b/examples/simple_udp.rs
@@ -7,7 +7,7 @@ use crossbeam_channel::{Receiver, Sender};
 use laminar::{ErrorKind, Packet, Socket, SocketEvent};
 use serde_derive::{Deserialize, Serialize};
 use std::net::SocketAddr;
-use std::{thread, time};
+use std::{thread, time::Instant};
 
 /// The socket address of where the server is located.
 const SERVER_ADDR: &'static str = "127.0.0.1:12345";
@@ -25,41 +25,60 @@ fn server_address() -> SocketAddr {
 /// This will run an simple example with client and server communicating.
 #[allow(unused_must_use)]
 pub fn main() {
-    let mut server = Server::new();
-    // set up or `Server` that will receive the messages we send with the `Client`
-    let handle = thread::spawn(move || loop {
-        server.receive();
-    });
-
-    thread::sleep(time::Duration::from_millis(100));
+    let mut server = Socket::bind(server_address()).unwrap();
 
     /*  setup or `Client` and send some test data. */
-    let mut client = Client::new();
+    let mut client = Socket::bind(client_address()).unwrap();
 
-    client.send(DataType::Coords {
-        latitude: 10.55454,
-        longitude: 10.555,
-        altitude: 1.3,
-    });
+    client.send(Packet::unreliable(
+        server_address(),
+        serialize(&DataType::Coords {
+            latitude: 10.55454,
+            longitude: 10.555,
+            altitude: 1.3,
+        })
+        .unwrap(),
+    ));
 
-    client.send(DataType::Coords {
-        latitude: 3.344,
-        longitude: 5.4545,
-        altitude: 1.33,
-    });
+    client.send(Packet::unreliable(
+        server_address(),
+        serialize(&DataType::Coords {
+            latitude: 3.344,
+            longitude: 5.4545,
+            altitude: 1.33,
+        })
+        .unwrap(),
+    ));
 
-    client.send(DataType::Text {
-        string: String::from("Some information"),
-    });
+    client.send(Packet::unreliable(
+        server_address(),
+        serialize(&DataType::Text {
+            string: String::from("Some information"),
+        })
+        .unwrap(),
+    ));
+
+    // Send the queued send operations
+    client.manual_poll(Instant::now());
+
+    // Check for any new packets
+    server.manual_poll(Instant::now());
 
     // ==== results ====
-    // Moving to lat: 10.555, long: 10.55454, alt: 1.3
-    // Moving to lat: 5.4545, long: 3.344, alt: 1.33
-    // Received text: "Some information"
-    handle.join();
+    // Coords { longitude: 10.555, latitude: 10.55454, altitude: 1.3 }
+    // Coords { longitude: 5.4545, latitude: 3.344, altitude: 1.33 }
+    // Text { string: "Some information" }
+    while let Some(pkt) = server.recv() {
+        match pkt {
+            SocketEvent::Packet(pkt) => {
+                println!["{:?}", deserialize::<DataType>(pkt.payload()).unwrap()]
+            }
+            _ => {}
+        }
+    }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 enum DataType {
     Coords {
         longitude: f32,
@@ -69,101 +88,4 @@ enum DataType {
     Text {
         string: String,
     },
-}
-
-/// This is an test server we use to receive data from clients.
-struct Server {
-    _packet_sender: Sender<Packet>,
-    event_receiver: Receiver<SocketEvent>,
-    _polling_thread: thread::JoinHandle<()>,
-}
-
-impl Server {
-    pub fn new() -> Self {
-        // setup an udp socket and bind it to the client address.
-        let (mut socket, packet_sender, event_receiver) = Socket::bind(server_address()).unwrap();
-        let polling_thread = thread::spawn(move || socket.start_polling());
-        Server {
-            _packet_sender: packet_sender,
-            event_receiver,
-            _polling_thread: polling_thread,
-        }
-    }
-
-    /// Receive and block the current thread.
-    pub fn receive(&mut self) {
-        // Next start receiving.
-        let result = self.event_receiver.recv();
-
-        match result {
-            Ok(SocketEvent::Packet(packet)) => {
-                let received_data: &[u8] = packet.payload();
-
-                // deserialize bytes to `DataType` we passed in with `Client.send()`.
-                let deserialized: DataType = deserialize(&received_data).unwrap();
-
-                self.perform_action(deserialized);
-            }
-            Ok(SocketEvent::Timeout(address)) => {
-                println!("A client timed out: {}", address);
-            }
-            Ok(_) => {}
-            Err(e) => {
-                println!("Something went wrong when receiving, error: {:?}", e);
-            }
-        }
-    }
-
-    /// Perform some processing of the data we have received.
-    fn perform_action(&self, data_type: DataType) {
-        match data_type {
-            DataType::Coords {
-                longitude,
-                latitude,
-                altitude,
-            } => {
-                println!(
-                    "Moving to lat: {}, long: {}, alt: {}",
-                    longitude, latitude, altitude
-                );
-            }
-            DataType::Text { string } => {
-                println!("Received text: {:?}", string);
-            }
-        }
-    }
-}
-
-/// This is an test client to send data to the server.
-struct Client {
-    packet_sender: Sender<Packet>,
-    _event_receiver: Receiver<SocketEvent>,
-    _polling_thread: thread::JoinHandle<()>,
-}
-
-impl Client {
-    pub fn new() -> Self {
-        // setup an udp socket and bind it to the client address.
-        let (mut socket, packet_sender, event_receiver) = Socket::bind(client_address()).unwrap();
-        let polling_thread = thread::spawn(move || socket.start_polling());
-
-        Client {
-            packet_sender,
-            _event_receiver: event_receiver,
-            _polling_thread: polling_thread,
-        }
-    }
-
-    pub fn send(&mut self, data_type: DataType) {
-        let serialized = serialize(&data_type);
-
-        match serialized {
-            Ok(raw_data) => {
-                self.packet_sender
-                    .send(Packet::reliable_unordered(server_address(), raw_data))
-                    .unwrap();
-            }
-            Err(e) => println!("Some error occurred: {:?}", e),
-        }
-    }
 }

--- a/examples/udp.rs
+++ b/examples/udp.rs
@@ -23,40 +23,38 @@ fn server_address() -> SocketAddr {
 /// This is an example of how to send data to an specific address.
 pub fn send_data() {
     // Setup a udp socket and bind it to the client address.
-    let (mut socket, packet_sender, _event_receiver) = Socket::bind(client_address()).unwrap();
-    let _thread = thread::spawn(move || socket.start_polling());
+    let mut socket = Socket::bind(client_address()).unwrap();
 
     let packet = construct_packet();
 
     // next send or packet to the endpoint we earlier putted into the packet.
-    packet_sender.send(packet).unwrap();
+    socket.send(packet);
 }
 
-/// This is an example of how to receive data over udp on an specific socket address.
+/// This is an example of how to receive data over udp.
 pub fn receive_data() {
     // setup an udp socket and bind it to the client address.
-    let (mut socket, _packet_sender, event_receiver) = Socket::bind(server_address()).unwrap();
-    let _thread = thread::spawn(move || socket.start_polling());
+    let mut socket = Socket::bind(server_address()).unwrap();
 
     // Next start receiving.
-    let result = event_receiver.recv();
+    loop {
+        if let Some(result) = socket.recv() {
+            match result {
+                SocketEvent::Packet(packet) => {
+                    let endpoint: SocketAddr = packet.addr();
+                    let received_data: &[u8] = packet.payload();
 
-    match result {
-        Ok(SocketEvent::Packet(packet)) => {
-            let endpoint: SocketAddr = packet.addr();
-            let received_data: &[u8] = packet.payload();
+                    // you can here deserialize your bytes into the data you have passed it when sending.
 
-            // you can here deserialize your bytes into the data you have passed it when sending.
-
-            println!(
-                "Received packet from: {:?} with length {}",
-                endpoint,
-                received_data.len()
-            );
-        }
-        Ok(_) => {}
-        Err(e) => {
-            println!("Something went wrong when receiving, error: {:?}", e);
+                    println!(
+                        "Received packet from: {:?} with length {}",
+                        endpoint,
+                        received_data.len()
+                    );
+                }
+                _ => {}
+            }
+            break;
         }
     }
 }

--- a/src/bin/cli.yml
+++ b/src/bin/cli.yml
@@ -12,15 +12,8 @@ subcommands:
                 required: true
                 takes_value: true
                 long: bind-host
-                default_value: "127.0.0.1"
+                default_value: "127.0.0.1:2264"
                 short: h
-            - LISTEN_PORT:
-                help: "Which port the server should listen on"
-                required: true
-                takes_value: true
-                long: bind-port
-                default_value: "2264"
-                short: p
             - SHUTDOWN_TIMER:
                 help: "The number of seconds the server will remain running, then shut itself down"
                 required: false
@@ -31,34 +24,20 @@ subcommands:
     - client:
         about: Starts the tester in client mode
         args:
-            - CONNECT_HOST:
+            - CONNECT_ADDR:
                 help: "Which host the client will connect to, as a hostname or IP address"
                 required: true
                 takes_value: true
                 long: connect-host
-                default_value: "127.0.0.1"
+                default_value: "127.0.0.1:2264"
                 short: H
-            - CONNECT_PORT:
-                help: "Which port the client will connect to"
-                required: true
-                takes_value: true
-                long: connect-port
-                default_value: "2264"
-                short: P
             - LISTEN_HOST:
                 help: "Which host the client should bind to. 0.0.0.0/0 will bind to all"
                 required: true
                 takes_value: true
                 long: bind-host
-                default_value: "127.0.0.1"
+                default_value: "127.0.0.1:2265"
                 short: h
-            - LISTEN_PORT:
-                help: "Which port the client should listen on"
-                required: true
-                takes_value: true
-                long: bind-port
-                default_value: "2265"
-                short: p
             - TEST_TO_RUN:
                 help: "Which client test to run. Run 'laminar-tester show-tests' to see all available"
                 required: true
@@ -84,6 +63,13 @@ subcommands:
                 takes_value: true
                 long: pps
                 default_value: "60"
+            - SHUTDOWN_TIMER:
+                help: "The number of seconds the client will remain running, then shut itself down"
+                required: false
+                default_value: "600"
+                takes_value: true
+                long: shutdown
+                short: s
     - show-tests:
         about: Shows all tests available
         subcommands:

--- a/src/net/socket.rs
+++ b/src/net/socket.rs
@@ -82,6 +82,16 @@ impl Socket {
         })
     }
 
+    /// Returns a handle to the packet sender which provides a thread-safe way to enqueue packets to be processed. This should be used when the socket is busy running its polling loop in a separate thread.
+    pub fn get_packet_sender(&mut self) -> Sender<Packet> {
+        self.sender.clone()
+    }
+
+    /// Returns a handle to the event receiver which provides a thread-safe way to retrieve events from the socket. This should be used when the socket is busy running its polling loop in a separate thread.
+    pub fn get_event_receiver(&mut self) -> Receiver<SocketEvent> {
+        self.receiver.clone()
+    }
+
     /// Send a packet
     pub fn send(&mut self, packet: Packet) -> Result<()> {
         match self.sender.send(packet) {
@@ -304,6 +314,35 @@ mod tests {
     fn binding_to_any() {
         assert![Socket::bind_any().is_ok()];
         assert![Socket::bind_any_with_config(Config::default()).is_ok()];
+    }
+
+    #[test]
+    fn using_sender_and_receiver() {
+        let server_addr = "127.0.0.1:12310".parse::<SocketAddr>().unwrap();
+        let client_addr = "127.0.0.1:12311".parse::<SocketAddr>().unwrap();
+
+        let mut server = Socket::bind(server_addr).unwrap();
+        let mut client = Socket::bind(client_addr).unwrap();
+
+        let time = Instant::now();
+
+        let mut sender = client.get_packet_sender();
+        let mut receiver = server.get_event_receiver();
+
+        sender.send(Packet::reliable_unordered(
+            server_addr,
+            b"Hello world!".iter().cloned().collect::<Vec<_>>(),
+        ));
+
+        client.manual_poll(time);
+        server.manual_poll(time);
+
+        assert_eq![Ok(SocketEvent::Connect(client_addr)), receiver.recv()];
+        if let SocketEvent::Packet(packet) = receiver.recv().unwrap() {
+            assert_eq![b"Hello world!", packet.payload()];
+        } else {
+            panic!["Did not receive a packet when it should"];
+        }
     }
 
     #[test]

--- a/src/net/socket.rs
+++ b/src/net/socket.rs
@@ -5,7 +5,7 @@ use crate::{
     net::{connection::ActiveConnections, events::SocketEvent, link_conditioner::LinkConditioner},
     packet::{DeliveryGuarantee, Outgoing, Packet},
 };
-use crossbeam_channel::{self, unbounded, Receiver, Sender};
+use crossbeam_channel::{self, unbounded, Receiver, SendError, Sender, TryRecvError};
 use log::error;
 use std::{
     self, io,
@@ -23,6 +23,9 @@ pub struct Socket {
     link_conditioner: Option<LinkConditioner>,
     event_sender: Sender<SocketEvent>,
     packet_receiver: Receiver<Packet>,
+
+    receiver: Receiver<SocketEvent>,
+    sender: Sender<Packet>,
 }
 
 enum UdpSocketState {
@@ -34,21 +37,17 @@ impl Socket {
     /// Binds to the socket and then sets up `ActiveConnections` to manage the "connections".
     /// Because UDP connections are not persistent, we can only infer the status of the remote
     /// endpoint by looking to see if they are still sending packets or not
-    pub fn bind<A: ToSocketAddrs>(
-        addresses: A,
-    ) -> Result<(Self, Sender<Packet>, Receiver<SocketEvent>)> {
+    pub fn bind<A: ToSocketAddrs>(addresses: A) -> Result<Self> {
         Socket::bind_with_config(addresses, Config::default())
     }
 
     /// Bind to any local port on the system, if available
-    pub fn bind_any() -> Result<(Self, Sender<Packet>, Receiver<SocketEvent>)> {
+    pub fn bind_any() -> Result<Self> {
         Self::bind_any_with_config(Config::default())
     }
 
     /// Bind to any local port on the system, if available, with a given config
-    pub fn bind_any_with_config(
-        config: Config,
-    ) -> Result<(Self, Sender<Packet>, Receiver<SocketEvent>)> {
+    pub fn bind_any_with_config(config: Config) -> Result<Self> {
         let loopback = Ipv4Addr::new(127, 0, 0, 1);
         let address = SocketAddrV4::new(loopback, 0);
         let socket = UdpSocket::bind(address)?;
@@ -60,34 +59,46 @@ impl Socket {
     /// endpoint by looking to see if they are still sending packets or not
     ///
     /// This function allows you to configure laminar with the passed configuration.
-    pub fn bind_with_config<A: ToSocketAddrs>(
-        addresses: A,
-        config: Config,
-    ) -> Result<(Self, Sender<Packet>, Receiver<SocketEvent>)> {
+    pub fn bind_with_config<A: ToSocketAddrs>(addresses: A, config: Config) -> Result<Self> {
         let socket = UdpSocket::bind(addresses)?;
         Self::bind_internal(socket, config)
     }
 
-    fn bind_internal(
-        socket: UdpSocket,
-        config: Config,
-    ) -> Result<(Self, Sender<Packet>, Receiver<SocketEvent>)> {
+    fn bind_internal(socket: UdpSocket, config: Config) -> Result<Self> {
         socket.set_nonblocking(true)?;
         let (event_sender, event_receiver) = unbounded();
         let (packet_sender, packet_receiver) = unbounded();
-        Ok((
-            Socket {
-                recv_buffer: vec![0; config.receive_buffer_max_size],
-                socket,
-                config,
-                connections: ActiveConnections::new(),
-                link_conditioner: None,
-                event_sender,
-                packet_receiver,
-            },
-            packet_sender,
-            event_receiver,
-        ))
+        Ok(Socket {
+            recv_buffer: vec![0; config.receive_buffer_max_size],
+            socket,
+            config,
+            connections: ActiveConnections::new(),
+            link_conditioner: None,
+            event_sender,
+            packet_receiver,
+
+            sender: packet_sender,
+            receiver: event_receiver,
+        })
+    }
+
+    /// Send a packet
+    pub fn send(&mut self, packet: Packet) -> Result<()> {
+        match self.sender.send(packet) {
+            Ok(_) => Ok(()),
+            Err(error) => Err(ErrorKind::SendError(SendError(SocketEvent::Packet(
+                error.0,
+            )))),
+        }
+    }
+
+    /// Receive a packet
+    pub fn recv(&mut self) -> Option<SocketEvent> {
+        match self.receiver.try_recv() {
+            Ok(pkt) => Some(pkt),
+            Err(TryRecvError::Empty) => None,
+            Err(TryRecvError::Disconnected) => panic!["This can never happen"],
+        }
     }
 
     /// Entry point to the run loop. This should run in a spawned thread since calls to `poll.poll`
@@ -297,20 +308,16 @@ mod tests {
 
     #[test]
     fn initial_packet_is_resent() {
-        let (mut server, server_sender, server_receiver) =
-            Socket::bind("127.0.0.1:12335".parse::<SocketAddr>().unwrap()).unwrap();
-        let (mut client, client_sender, client_receiver) =
-            Socket::bind("127.0.0.1:12336".parse::<SocketAddr>().unwrap()).unwrap();
+        let mut server = Socket::bind("127.0.0.1:12335".parse::<SocketAddr>().unwrap()).unwrap();
+        let mut client = Socket::bind("127.0.0.1:12336".parse::<SocketAddr>().unwrap()).unwrap();
 
         let time = Instant::now();
 
         // Send a packet that the server ignores/drops
-        client_sender
-            .send(Packet::reliable_unordered(
-                "127.0.0.1:12335".parse::<SocketAddr>().unwrap(),
-                b"Do not arrive".iter().cloned().collect::<Vec<_>>(),
-            ))
-            .unwrap();
+        client.send(Packet::reliable_unordered(
+            "127.0.0.1:12335".parse::<SocketAddr>().unwrap(),
+            b"Do not arrive".iter().cloned().collect::<Vec<_>>(),
+        ));
         client.manual_poll(time);
 
         // Drop the inbound packet, this simulates a network error
@@ -318,23 +325,19 @@ mod tests {
 
         // Send a packet that the server receives
         for id in 0..u8::max_value() {
-            client_sender
-                .send(create_test_packet(id, "127.0.0.1:12335"))
-                .unwrap();
+            client.send(create_test_packet(id, "127.0.0.1:12335"));
 
-            server_sender
-                .send(create_test_packet(id, "127.0.0.1:12336"))
-                .unwrap();
+            server.send(create_test_packet(id, "127.0.0.1:12336"));
 
             client.manual_poll(time);
             server.manual_poll(time);
 
-            while let Ok(SocketEvent::Packet(pkt)) = server_receiver.try_recv() {
+            while let Some(SocketEvent::Packet(pkt)) = server.recv() {
                 if pkt.payload() == b"Do not arrive" {
                     return;
                 }
             }
-            while let Ok(_) = client_receiver.try_recv() {}
+            while let Some(_) = client.recv() {}
         }
 
         panic!["Did not receive the ignored packet"];
@@ -342,19 +345,15 @@ mod tests {
 
     #[test]
     fn receiving_does_not_allow_denial_of_service() {
-        let (mut server, server_sender, packet_receiver) =
-            Socket::bind("127.0.0.1:12337".parse::<SocketAddr>().unwrap()).unwrap();
-        let (mut client, client_sender, _) =
-            Socket::bind("127.0.0.1:12338".parse::<SocketAddr>().unwrap()).unwrap();
+        let mut server = Socket::bind("127.0.0.1:12337".parse::<SocketAddr>().unwrap()).unwrap();
+        let mut client = Socket::bind("127.0.0.1:12338".parse::<SocketAddr>().unwrap()).unwrap();
 
         // Send a bunch of packets to a server
         for _ in 0..3 {
-            client_sender
-                .send(Packet::unreliable(
-                    "127.0.0.1:12337".parse::<SocketAddr>().unwrap(),
-                    vec![1, 2, 3, 4, 5, 6, 7, 8, 9],
-                ))
-                .unwrap();
+            client.send(Packet::unreliable(
+                "127.0.0.1:12337".parse::<SocketAddr>().unwrap(),
+                vec![1, 2, 3, 4, 5, 6, 7, 8, 9],
+            ));
         }
 
         let time = Instant::now();
@@ -363,20 +362,18 @@ mod tests {
         server.manual_poll(time);
 
         for _ in 0..6 {
-            assert![packet_receiver.try_recv().is_ok()];
+            assert![server.recv().is_some()];
         }
-        assert![packet_receiver.try_recv().is_err()];
+        assert![server.recv().is_none()];
 
         // The server shall not have any connection in its connection table even though it received
         // packets
         assert_eq![0, server.connection_count()];
 
-        server_sender
-            .send(Packet::unreliable(
-                "127.0.0.1:12338".parse::<SocketAddr>().unwrap(),
-                vec![1],
-            ))
-            .unwrap();
+        server.send(Packet::unreliable(
+            "127.0.0.1:12338".parse::<SocketAddr>().unwrap(),
+            vec![1],
+        ));
 
         server.manual_poll(time);
 
@@ -386,21 +383,17 @@ mod tests {
 
     #[test]
     fn initial_sequenced_is_resent() {
-        let (mut server, server_sender, server_receiver) =
-            Socket::bind("127.0.0.1:12329".parse::<SocketAddr>().unwrap()).unwrap();
-        let (mut client, client_sender, client_receiver) =
-            Socket::bind("127.0.0.1:12330".parse::<SocketAddr>().unwrap()).unwrap();
+        let mut server = Socket::bind("127.0.0.1:12329".parse::<SocketAddr>().unwrap()).unwrap();
+        let mut client = Socket::bind("127.0.0.1:12330".parse::<SocketAddr>().unwrap()).unwrap();
 
         let time = Instant::now();
 
         // Send a packet that the server ignores/drops
-        client_sender
-            .send(Packet::reliable_sequenced(
-                "127.0.0.1:12329".parse::<SocketAddr>().unwrap(),
-                b"Do not arrive".iter().cloned().collect::<Vec<_>>(),
-                None,
-            ))
-            .unwrap();
+        client.send(Packet::reliable_sequenced(
+            "127.0.0.1:12329".parse::<SocketAddr>().unwrap(),
+            b"Do not arrive".iter().cloned().collect::<Vec<_>>(),
+            None,
+        ));
         client.manual_poll(time);
 
         // Drop the inbound packet, this simulates a network error
@@ -408,43 +401,35 @@ mod tests {
 
         // Send a packet that the server receives
         for id in 0..36 {
-            client_sender
-                .send(create_sequenced_packet(id, "127.0.0.1:12329"))
-                .unwrap();
+            client.send(create_sequenced_packet(id, "127.0.0.1:12329"));
 
-            server_sender
-                .send(create_sequenced_packet(id, "127.0.0.1:12330"))
-                .unwrap();
+            server.send(create_sequenced_packet(id, "127.0.0.1:12330"));
 
             client.manual_poll(time);
             server.manual_poll(time);
 
-            while let Ok(SocketEvent::Packet(pkt)) = server_receiver.try_recv() {
+            while let Some(SocketEvent::Packet(pkt)) = server.recv() {
                 if pkt.payload() == b"Do not arrive" {
                     panic!["Sequenced packet arrived while it should not"];
                 }
             }
-            while let Ok(_) = client_receiver.try_recv() {}
+            while let Some(_) = client.recv() {}
         }
     }
 
     #[test]
     fn initial_ordered_is_resent() {
-        let (mut server, server_sender, server_receiver) =
-            Socket::bind("127.0.0.1:12333".parse::<SocketAddr>().unwrap()).unwrap();
-        let (mut client, client_sender, client_receiver) =
-            Socket::bind("127.0.0.1:12334".parse::<SocketAddr>().unwrap()).unwrap();
+        let mut server = Socket::bind("127.0.0.1:12333".parse::<SocketAddr>().unwrap()).unwrap();
+        let mut client = Socket::bind("127.0.0.1:12334".parse::<SocketAddr>().unwrap()).unwrap();
 
         let time = Instant::now();
 
         // Send a packet that the server ignores/drops
-        client_sender
-            .send(Packet::reliable_ordered(
-                "127.0.0.1:12333".parse::<SocketAddr>().unwrap(),
-                b"Do not arrive".iter().cloned().collect::<Vec<_>>(),
-                None,
-            ))
-            .unwrap();
+        client.send(Packet::reliable_ordered(
+            "127.0.0.1:12333".parse::<SocketAddr>().unwrap(),
+            b"Do not arrive".iter().cloned().collect::<Vec<_>>(),
+            None,
+        ));
         client.manual_poll(time);
 
         // Drop the inbound packet, this simulates a network error
@@ -452,23 +437,19 @@ mod tests {
 
         // Send a packet that the server receives
         for id in 0..36 {
-            client_sender
-                .send(create_ordered_packet(id, "127.0.0.1:12333"))
-                .unwrap();
+            client.send(create_ordered_packet(id, "127.0.0.1:12333"));
 
-            server_sender
-                .send(create_ordered_packet(id, "127.0.0.1:12334"))
-                .unwrap();
+            server.send(create_ordered_packet(id, "127.0.0.1:12334"));
 
             client.manual_poll(time);
             server.manual_poll(time);
 
-            while let Ok(SocketEvent::Packet(pkt)) = server_receiver.try_recv() {
+            while let Some(SocketEvent::Packet(pkt)) = server.recv() {
                 if pkt.payload() == b"Do not arrive" {
                     return;
                 }
             }
-            while let Ok(_) = client_receiver.try_recv() {}
+            while let Some(_) = client.recv() {}
         }
 
         panic!["Did not receive the ignored packet"];
@@ -479,22 +460,20 @@ mod tests {
         let server_addr = "127.0.0.1:12325".parse::<SocketAddr>().unwrap();
         let client_addr = "127.0.0.1:12326".parse::<SocketAddr>().unwrap();
 
-        let (mut server, server_sender, server_receiver) = Socket::bind(server_addr).unwrap();
-        let (mut client, client_sender, client_receiver) = Socket::bind(client_addr).unwrap();
+        let mut server = Socket::bind(server_addr).unwrap();
+        let mut client = Socket::bind(client_addr).unwrap();
 
         let time = Instant::now();
 
         for id in 0..100 {
-            client_sender
-                .send(Packet::reliable_sequenced(server_addr, vec![id], None))
-                .unwrap();
+            client.send(Packet::reliable_sequenced(server_addr, vec![id], None));
             client.manual_poll(time);
             server.manual_poll(time);
         }
 
         let mut seen = HashSet::new();
 
-        while let Ok(message) = server_receiver.try_recv() {
+        while let Some(message) = server.recv() {
             match message {
                 SocketEvent::Connect(connect_event) => {}
                 SocketEvent::Packet(packet) => {
@@ -515,18 +494,14 @@ mod tests {
 
     #[test]
     fn manual_polling_socket() {
-        let (mut server, _, packet_receiver) =
-            Socket::bind("127.0.0.1:12339".parse::<SocketAddr>().unwrap()).unwrap();
-        let (mut client, packet_sender, _) =
-            Socket::bind("127.0.0.1:12340".parse::<SocketAddr>().unwrap()).unwrap();
+        let mut server = Socket::bind("127.0.0.1:12339".parse::<SocketAddr>().unwrap()).unwrap();
+        let mut client = Socket::bind("127.0.0.1:12340".parse::<SocketAddr>().unwrap()).unwrap();
 
         for _ in 0..3 {
-            packet_sender
-                .send(Packet::unreliable(
-                    "127.0.0.1:12339".parse::<SocketAddr>().unwrap(),
-                    vec![1, 2, 3, 4, 5, 6, 7, 8, 9],
-                ))
-                .unwrap();
+            client.send(Packet::unreliable(
+                "127.0.0.1:12339".parse::<SocketAddr>().unwrap(),
+                vec![1, 2, 3, 4, 5, 6, 7, 8, 9],
+            ));
         }
 
         let time = Instant::now();
@@ -534,43 +509,35 @@ mod tests {
         client.manual_poll(time);
         server.manual_poll(time);
 
-        let mut iter = packet_receiver.iter();
-
-        assert!(iter.next().is_some());
-        assert!(iter.next().is_some());
-        assert!(iter.next().is_some());
+        assert!(server.recv().is_some());
+        assert!(server.recv().is_some());
+        assert!(server.recv().is_some());
     }
 
     #[test]
     fn can_send_and_receive() {
-        let (mut server, _, packet_receiver) =
-            Socket::bind("127.0.0.1:12342".parse::<SocketAddr>().unwrap()).unwrap();
-        let (mut client, packet_sender, _) =
-            Socket::bind("127.0.0.1:12341".parse::<SocketAddr>().unwrap()).unwrap();
-
-        thread::spawn(move || client.start_polling());
-        thread::spawn(move || server.start_polling());
+        let mut server = Socket::bind("127.0.0.1:12342".parse::<SocketAddr>().unwrap()).unwrap();
+        let mut client = Socket::bind("127.0.0.1:12341".parse::<SocketAddr>().unwrap()).unwrap();
 
         for _ in 0..3 {
-            packet_sender
-                .send(Packet::unreliable(
-                    "127.0.0.1:12342".parse::<SocketAddr>().unwrap(),
-                    vec![1, 2, 3, 4, 5, 6, 7, 8, 9],
-                ))
-                .unwrap();
+            client.send(Packet::unreliable(
+                "127.0.0.1:12342".parse::<SocketAddr>().unwrap(),
+                vec![1, 2, 3, 4, 5, 6, 7, 8, 9],
+            ));
         }
 
-        let mut iter = packet_receiver.iter();
+        let now = Instant::now();
+        client.manual_poll(now);
+        server.manual_poll(now);
 
-        assert!(iter.next().is_some());
-        assert!(iter.next().is_some());
-        assert!(iter.next().is_some());
+        assert!(server.recv().is_some());
+        assert!(server.recv().is_some());
+        assert!(server.recv().is_some());
     }
 
     #[test]
     fn sending_large_unreliable_packet_should_fail() {
-        let (mut server, _, _) =
-            Socket::bind("127.0.0.1:12370".parse::<SocketAddr>().unwrap()).unwrap();
+        let mut server = Socket::bind("127.0.0.1:12370".parse::<SocketAddr>().unwrap()).unwrap();
 
         assert_eq!(
             server
@@ -585,8 +552,7 @@ mod tests {
 
     #[test]
     fn send_returns_right_size() {
-        let (mut server, _, _) =
-            Socket::bind("127.0.0.1:12371".parse::<SocketAddr>().unwrap()).unwrap();
+        let mut server = Socket::bind("127.0.0.1:12371".parse::<SocketAddr>().unwrap()).unwrap();
 
         assert_eq!(
             server
@@ -601,8 +567,7 @@ mod tests {
 
     #[test]
     fn fragmentation_send_returns_right_size() {
-        let (mut server, _, _) =
-            Socket::bind("127.0.0.1:12372".parse::<SocketAddr>().unwrap()).unwrap();
+        let mut server = Socket::bind("127.0.0.1:12372".parse::<SocketAddr>().unwrap()).unwrap();
 
         let fragment_packet_size = STANDARD_HEADER_SIZE + FRAGMENT_HEADER_SIZE;
 
@@ -620,22 +585,20 @@ mod tests {
 
     #[test]
     fn connect_event_occurs() {
-        let (mut server, _, packet_receiver) =
-            Socket::bind("127.0.0.1:12345".parse::<SocketAddr>().unwrap()).unwrap();
-        let (mut client, packet_sender, _) =
-            Socket::bind("127.0.0.1:12344".parse::<SocketAddr>().unwrap()).unwrap();
+        let mut server = Socket::bind("127.0.0.1:12345".parse::<SocketAddr>().unwrap()).unwrap();
+        let mut client = Socket::bind("127.0.0.1:12344".parse::<SocketAddr>().unwrap()).unwrap();
 
-        thread::spawn(move || client.start_polling());
-        thread::spawn(move || server.start_polling());
+        client.send(Packet::unreliable(
+            "127.0.0.1:12345".parse().unwrap(),
+            vec![0, 1, 2],
+        ));
 
-        packet_sender
-            .send(Packet::unreliable(
-                "127.0.0.1:12345".parse().unwrap(),
-                vec![0, 1, 2],
-            ))
-            .unwrap();
+        let now = Instant::now();
+        client.manual_poll(now);
+        server.manual_poll(now);
+
         assert_eq!(
-            packet_receiver.recv().unwrap(),
+            server.recv().unwrap(),
             SocketEvent::Connect("127.0.0.1:12344".parse().unwrap())
         );
     }
@@ -645,27 +608,24 @@ mod tests {
         let mut config = Config::default();
         config.idle_connection_timeout = Duration::from_millis(1);
 
-        let (mut server, server_sender, server_receiver) =
-            Socket::bind("127.0.0.1:12347".parse::<SocketAddr>().unwrap()).unwrap();
-        let (mut client, client_sender, _) =
-            Socket::bind("127.0.0.1:12346".parse::<SocketAddr>().unwrap()).unwrap();
+        let mut server = Socket::bind("127.0.0.1:12347".parse::<SocketAddr>().unwrap()).unwrap();
+        let mut client = Socket::bind("127.0.0.1:12346".parse::<SocketAddr>().unwrap()).unwrap();
 
-        thread::spawn(move || client.start_polling());
-        thread::spawn(move || server.start_polling());
+        client.send(Packet::unreliable(
+            "127.0.0.1:12347".parse().unwrap(),
+            vec![0, 1, 2],
+        ));
 
-        client_sender
-            .send(Packet::unreliable(
-                "127.0.0.1:12347".parse().unwrap(),
-                vec![0, 1, 2],
-            ))
-            .unwrap();
+        let now = Instant::now();
+        client.manual_poll(now);
+        server.manual_poll(now);
 
         assert_eq!(
-            server_receiver.recv().unwrap(),
+            server.recv().unwrap(),
             SocketEvent::Connect("127.0.0.1:12346".parse().unwrap())
         );
         assert_eq!(
-            server_receiver.recv().unwrap(),
+            server.recv().unwrap(),
             SocketEvent::Packet(Packet::unreliable(
                 "127.0.0.1:12346".parse().unwrap(),
                 vec![0, 1, 2]
@@ -673,15 +633,17 @@ mod tests {
         );
 
         // Acknowledge the client
-        server_sender
-            .send(Packet::unreliable(
-                "127.0.0.1:12346".parse().unwrap(),
-                vec![],
-            ))
-            .unwrap();
+        server.send(Packet::unreliable(
+            "127.0.0.1:12346".parse().unwrap(),
+            vec![],
+        ));
+
+        server.manual_poll(now);
+        client.manual_poll(now);
+        server.manual_poll(now + Duration::new(5, 0));
 
         assert_eq!(
-            server_receiver.recv().unwrap(),
+            server.recv().unwrap(),
             SocketEvent::Timeout("127.0.0.1:12346".parse().unwrap())
         );
     }
@@ -707,25 +669,23 @@ mod tests {
     #[test]
     fn multiple_sends_should_start_sending_dropped() {
         // Start up a server and a client.
-        let (mut server, server_sender, server_receiver) =
-            Socket::bind(REMOTE_ADDR.parse::<SocketAddr>().unwrap()).unwrap();
-        thread::spawn(move || server.start_polling());
+        let mut server = Socket::bind(REMOTE_ADDR.parse::<SocketAddr>().unwrap()).unwrap();
 
-        let (mut client, client_sender, client_receiver) =
-            Socket::bind(LOCAL_ADDR.parse::<SocketAddr>().unwrap()).unwrap();
-        thread::spawn(move || client.start_polling());
+        let mut client = Socket::bind(LOCAL_ADDR.parse::<SocketAddr>().unwrap()).unwrap();
+
+        let now = Instant::now();
 
         // Send enough packets to ensure that we must have dropped packets.
         for i in 0..35 {
-            client_sender
-                .send(create_test_packet(i, REMOTE_ADDR))
-                .unwrap();
+            client.send(create_test_packet(i, REMOTE_ADDR));
         }
 
         let mut events = Vec::new();
 
         loop {
-            if let Ok(event) = server_receiver.recv_timeout(Duration::from_millis(500)) {
+            client.manual_poll(now);
+            server.manual_poll(now);
+            if let Some(event) = server.recv() {
                 events.push(event);
             } else {
                 break;
@@ -738,22 +698,26 @@ mod tests {
 
         // Finally the server decides to send us a message back. This necessarily will include
         // the ack information for 33 of the sent 35 packets.
-        server_sender
-            .send(create_test_packet(0, LOCAL_ADDR))
-            .unwrap();
+        server.send(create_test_packet(0, LOCAL_ADDR));
+
+        server.manual_poll(now);
+        client.manual_poll(now);
 
         // Block to ensure that the client gets the server message before moving on.
-        client_receiver.recv().unwrap();
+        client.recv();
 
         // This next sent message should end up sending the 2 unacked messages plus the new messages
         // with payload 35
         events.clear();
-        client_sender
-            .send(create_test_packet(35, REMOTE_ADDR))
-            .unwrap();
+        client.send(create_test_packet(35, REMOTE_ADDR));
+
+        client.manual_poll(now);
+        server.manual_poll(now);
 
         loop {
-            if let Ok(event) = server_receiver.recv_timeout(Duration::from_millis(500)) {
+            client.manual_poll(now);
+            server.manual_poll(now);
+            if let Some(event) = server.recv() {
                 events.push(event);
             } else {
                 break;
@@ -775,7 +739,7 @@ mod tests {
         let receiver = "127.0.0.1:12332".parse::<SocketAddr>().unwrap();
         let sender = "127.0.0.1:12331".parse::<SocketAddr>().unwrap();
 
-        let (mut server, server_sender, server_receiver) = Socket::bind(receiver).unwrap();
+        let mut server = Socket::bind(receiver).unwrap();
 
         let client = UdpSocket::bind(sender).unwrap();
 
@@ -790,8 +754,8 @@ mod tests {
         let server_addr = "127.0.0.1:12320".parse::<SocketAddr>().unwrap();
         let client_addr = "127.0.0.1:12321".parse::<SocketAddr>().unwrap();
 
-        let (mut server, server_sender, server_receiver) = Socket::bind(server_addr).unwrap();
-        let (mut client, client_sender, client_receiver) = Socket::bind(client_addr).unwrap();
+        let mut server = Socket::bind(server_addr).unwrap();
+        let mut client = Socket::bind(client_addr).unwrap();
 
         let time = Instant::now();
 
@@ -811,22 +775,18 @@ mod tests {
         // packets
         let mut send_many_packets = |dummy: Option<u8>| {
             for id in 0..100 {
-                client_sender
-                    .send(Packet::reliable_unordered(
-                        server_addr,
-                        vec![dummy.unwrap_or(id)],
-                    ))
-                    .unwrap();
+                client.send(Packet::reliable_unordered(
+                    server_addr,
+                    vec![dummy.unwrap_or(id)],
+                ));
 
-                server_sender
-                    .send(Packet::reliable_unordered(client_addr, vec![255]))
-                    .unwrap();
+                server.send(Packet::reliable_unordered(client_addr, vec![255]));
 
                 client.manual_poll(time);
                 server.manual_poll(time);
 
-                while let Ok(_) = client_receiver.try_recv() {}
-                while let Ok(event) = server_receiver.try_recv() {
+                while let Some(_) = client.recv() {}
+                while let Some(event) = server.recv() {
                     match event {
                         SocketEvent::Packet(pkt) => {
                             set.insert(pkt.payload()[0]);

--- a/tests/common/client.rs
+++ b/tests/common/client.rs
@@ -32,17 +32,14 @@ impl Client {
         let packets_to_send = self.packets_to_send;
 
         let handle = thread::spawn(move || {
-            let (mut socket, packet_sender, _) = Socket::bind(endpoint).unwrap();
-
-            let _thread = thread::spawn(move || socket.start_polling());
+            let mut socket = Socket::bind(endpoint).unwrap();
 
             info!("Client {:?} starts to send packets.", endpoint);
 
             for _ in 0..packets_to_send {
                 let packet = create_packet();
-                if let Err(e) = packet_sender.send(packet) {
-                    error!("Client can not send packet {:?}", e);
-                }
+                socket.send(packet);
+                socket.manual_poll(Instant::now());
 
                 let beginning_park = Instant::now();
                 let mut timeout_remaining = timeout;


### PR DESCRIPTION
The library should be agnostic to channels and multiple threads, meaning
that we give the user the ability to use it single-threadedly, or to
spawn threads which define their own queues that other threads can use.

This patch is the first step in that direction.

We do lose a blocking `recv` right now, but I think we can do that in a
smarter way, instead of `manual_poll` doing recv, we can let `recv` do a
direct receive on the socket instead.

Relevant issue: https://github.com/amethyst/laminar/issues/195