### PR TITLE
Remove the travis-ci badge. 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,6 @@ repository = "https://github.com/amethyst/laminar"
 autobenches = false
 edition = "2018"
 
-[badges]
-travis-ci = { repository = "amethyst/laminar", branch = "master" }
-
 [dependencies]
 byteorder = "1.2"
 crc = "1.8"


### PR DESCRIPTION
We don't use it anymore and it looks bad that it's failing