### PR TITLE
Remove mut requirement to methods which do not need it

### DIFF
--- a/examples/udp.rs
+++ b/examples/udp.rs
@@ -22,7 +22,7 @@ fn server_address() -> SocketAddr {
 /// This is an example of how to send data to an specific address.
 pub fn send_data() -> Result<()> {
     // Setup a udp socket and bind it to the client address.
-    let mut socket = Socket::bind(client_address()).unwrap();
+    let socket = Socket::bind(client_address()).unwrap();
 
     let packet = construct_packet();
 
@@ -33,7 +33,7 @@ pub fn send_data() -> Result<()> {
 /// This is an example of how to receive data over udp.
 pub fn receive_data() {
     // setup an udp socket and bind it to the client address.
-    let mut socket = Socket::bind(server_address()).unwrap();
+    let socket = Socket::bind(server_address()).unwrap();
 
     // Next start receiving.
     loop {

--- a/src/net/socket.rs
+++ b/src/net/socket.rs
@@ -86,19 +86,19 @@ impl Socket {
     /// Returns a handle to the packet sender which provides a thread-safe way to enqueue packets
     /// to be processed. This should be used when the socket is busy running its polling loop in a
     /// separate thread.
-    pub fn get_packet_sender(&mut self) -> Sender<Packet> {
+    pub fn get_packet_sender(&self) -> Sender<Packet> {
         self.sender.clone()
     }
 
     /// Returns a handle to the event receiver which provides a thread-safe way to retrieve events
     /// from the socket. This should be used when the socket is busy running its polling loop in
     /// a separate thread.
-    pub fn get_event_receiver(&mut self) -> Receiver<SocketEvent> {
+    pub fn get_event_receiver(&self) -> Receiver<SocketEvent> {
         self.receiver.clone()
     }
 
     /// Send a packet
-    pub fn send(&mut self, packet: Packet) -> Result<()> {
+    pub fn send(&self, packet: Packet) -> Result<()> {
         match self.sender.send(packet) {
             Ok(_) => Ok(()),
             Err(error) => Err(ErrorKind::SendError(SendError(SocketEvent::Packet(
@@ -108,7 +108,7 @@ impl Socket {
     }
 
     /// Receive a packet
-    pub fn recv(&mut self) -> Option<SocketEvent> {
+    pub fn recv(&self) -> Option<SocketEvent> {
         match self.receiver.try_recv() {
             Ok(pkt) => Some(pkt),
             Err(TryRecvError::Empty) => None,


### PR DESCRIPTION
When I was integrating Laminar in our demo project, I noticed that I needed write access to the resource holding the socket when sending and receiving which seemed odd to me. Indeed, it was, in fact, odd because these methods don't require mutable access to the socket.