### PR TITLE
Allow a Socket to be in blocking mode

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -4,6 +4,8 @@ use std::{default::Default, time::Duration};
 #[derive(Clone, Debug)]
 /// Contains the configuration options to configure laminar for special use-cases.
 pub struct Config {
+    /// Make the underlying UDP socket block when true, otherwise non-blocking.
+    pub blocking_mode: bool,
     /// Value which can specify the amount of time that can pass without hearing from a client before considering them disconnected
     pub idle_connection_timeout: Duration,
     /// Value which can specify the maximum size a packet can be in bytes. This value is inclusive of fragmenting; if a packet is fragmented, the total size of the fragments cannot exceed this value.
@@ -48,6 +50,7 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Self {
         Self {
+            blocking_mode: false,
             idle_connection_timeout: Duration::from_secs(5),
             max_packet_size: (MAX_FRAGMENTS_DEFAULT * FRAGMENT_SIZE_DEFAULT) as usize,
             max_fragments: MAX_FRAGMENTS_DEFAULT as u8,


### PR DESCRIPTION
This is a useful feature in testing. We've noticed from CI that there
are timing inconsistencies even with sequential non-blocking UDP
sockets. By blocking, we can force the OS to wait for the packet to be
available.

Exposing this in the public API makes this functionality also usable by
users of the library.

`Empty` was renamed `MaybeEmpty`, because it now means 2 things: The
kernel buffer is empty (in non-blocking mode this happens), or we simply
only want to retrieve 1 packet at a time.

I'm not entirely sure if we perhaps should use another enum entry here
or kind-of overload the name. Let me know if there are better
alternatives.