### PR TITLE
Implement heartbeat functionality

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -8,6 +8,9 @@ pub struct Config {
     pub blocking_mode: bool,
     /// Value which can specify the amount of time that can pass without hearing from a client before considering them disconnected
     pub idle_connection_timeout: Duration,
+    /// Value which specifies at which interval (if at all) a heartbeat should be sent, if no other packet was sent in the meantime.
+    /// If None, no heartbeats will be sent (the default).
+    pub heartbeat_interval: Option<Duration>,
     /// Value which can specify the maximum size a packet can be in bytes. This value is inclusive of fragmenting; if a packet is fragmented, the total size of the fragments cannot exceed this value.
     ///
     /// Recommended value: 16384
@@ -52,6 +55,7 @@ impl Default for Config {
         Self {
             blocking_mode: false,
             idle_connection_timeout: Duration::from_secs(5),
+            heartbeat_interval: None,
             max_packet_size: (MAX_FRAGMENTS_DEFAULT * FRAGMENT_SIZE_DEFAULT) as usize,
             max_fragments: MAX_FRAGMENTS_DEFAULT as u8,
             fragment_size: FRAGMENT_SIZE_DEFAULT,

--- a/src/net/connection.rs
+++ b/src/net/connection.rs
@@ -67,6 +67,18 @@ impl ActiveConnections {
             .collect()
     }
 
+    /// Check for and return `VirtualConnection`s which have not sent anything for a duration of at least `heartbeat_interval`.
+    pub fn heartbeat_required_connections(
+        &mut self,
+        heartbeat_interval: Duration,
+        time: Instant,
+    ) -> impl Iterator<Item = &mut VirtualConnection> {
+        self.connections
+            .iter_mut()
+            .filter(move |(_, connection)| connection.last_sent(time) >= heartbeat_interval)
+            .map(|(_, connection)| connection)
+    }
+
     /// Returns true if the given connection exists.
     pub fn exists(&self, address: &SocketAddr) -> bool {
         self.connections.contains_key(&address)

--- a/src/net/socket.rs
+++ b/src/net/socket.rs
@@ -156,9 +156,19 @@ impl Socket {
             }
         }
 
-        // Finally check for idle clients
+        // Check for idle clients
         if let Err(e) = self.handle_idle_clients(time) {
             error!("Encountered an error when sending TimeoutEvent: {:?}", e);
+        }
+
+        // Finally send heartbeat packets to connections that require them, if enabled
+        if let Some(heartbeat_interval) = self.config.heartbeat_interval {
+            if let Err(e) = self.send_heartbeat_packets(heartbeat_interval, time) {
+                match e {
+                    ErrorKind::IOError(ref e) if e.kind() == io::ErrorKind::WouldBlock => {}
+                    _ => error!("There was an error sending a heartbeat packet: {:?}", e),
+                }
+            }
         }
     }
 
@@ -185,6 +195,35 @@ impl Socket {
         }
 
         Ok(())
+    }
+
+    /// Iterate over all connections which have not sent a packet for a duration of at least
+    /// `heartbeat_interval` (from config), and send a heartbeat packet to each.
+    fn send_heartbeat_packets(
+        &mut self,
+        heartbeat_interval: Duration,
+        time: Instant,
+    ) -> Result<usize> {
+        let heartbeat_packets_and_addrs = self
+            .connections
+            .heartbeat_required_connections(heartbeat_interval, time)
+            .map(|connection| {
+                (
+                    connection.create_and_process_heartbeat(time),
+                    connection.remote_address,
+                )
+            })
+            .collect::<Vec<_>>();
+
+        let mut bytes_sent = 0;
+
+        for (heartbeat_packet, address) in heartbeat_packets_and_addrs {
+            if self.should_send_packet() {
+                bytes_sent += self.send_packet(&address, &heartbeat_packet.contents())?;
+            }
+        }
+
+        Ok(bytes_sent)
     }
 
     // Serializes and sends a `Packet` on the socket. On success, returns the number of bytes written.
@@ -737,52 +776,111 @@ mod tests {
         let mut config = Config::default();
         config.idle_connection_timeout = Duration::from_millis(1);
 
-        let mut server = Socket::bind("127.0.0.1:12347".parse::<SocketAddr>().unwrap()).unwrap();
-        let mut client = Socket::bind("127.0.0.1:12346".parse::<SocketAddr>().unwrap()).unwrap();
+        let server_addr = "127.0.0.1:12347".parse::<SocketAddr>().unwrap();
+        let client_addr = "127.0.0.1:12346".parse::<SocketAddr>().unwrap();
+
+        let mut server = Socket::bind_with_config(server_addr, config.clone()).unwrap();
+        let mut client = Socket::bind_with_config(client_addr, config.clone()).unwrap();
 
         client
-            .send(Packet::unreliable(
-                "127.0.0.1:12347".parse().unwrap(),
-                vec![0, 1, 2],
-            ))
+            .send(Packet::unreliable(server_addr, vec![0, 1, 2]))
             .unwrap();
 
         let now = Instant::now();
         client.manual_poll(now);
         server.manual_poll(now);
 
+        assert_eq!(server.recv().unwrap(), SocketEvent::Connect(client_addr));
         assert_eq!(
             server.recv().unwrap(),
-            SocketEvent::Connect("127.0.0.1:12346".parse().unwrap())
-        );
-        assert_eq!(
-            server.recv().unwrap(),
-            SocketEvent::Packet(Packet::unreliable(
-                "127.0.0.1:12346".parse().unwrap(),
-                vec![0, 1, 2]
-            ))
+            SocketEvent::Packet(Packet::unreliable(client_addr, vec![0, 1, 2]))
         );
 
         // Acknowledge the client
         server
-            .send(Packet::unreliable(
-                "127.0.0.1:12346".parse().unwrap(),
-                vec![],
-            ))
+            .send(Packet::unreliable(client_addr, vec![]))
             .unwrap();
 
         server.manual_poll(now);
         client.manual_poll(now);
-        server.manual_poll(now + Duration::new(5, 0));
 
+        // Make sure the connection was successful on the client side
         assert_eq!(
-            server.recv().unwrap(),
-            SocketEvent::Timeout("127.0.0.1:12346".parse().unwrap())
+            client.recv().unwrap(),
+            SocketEvent::Packet(Packet::unreliable(server_addr, vec![]))
         );
+
+        // Give just enough time for no timeout events to occur (yet)
+        server.manual_poll(now + config.idle_connection_timeout - Duration::from_millis(1));
+        client.manual_poll(now + config.idle_connection_timeout - Duration::from_millis(1));
+
+        assert_eq!(server.recv(), None);
+        assert_eq!(client.recv(), None);
+
+        // Give enough time for timeouts to be detected
+        server.manual_poll(now + config.idle_connection_timeout);
+        client.manual_poll(now + config.idle_connection_timeout);
+
+        assert_eq!(server.recv().unwrap(), SocketEvent::Timeout(client_addr));
+        assert_eq!(client.recv().unwrap(), SocketEvent::Timeout(server_addr));
     }
 
-    const LOCAL_ADDR: &str = "127.0.0.1:13000";
-    const REMOTE_ADDR: &str = "127.0.0.1:14000";
+    #[test]
+    fn heartbeats_work() {
+        let mut config = Config::default();
+        config.idle_connection_timeout = Duration::from_millis(10);
+        config.heartbeat_interval = Some(Duration::from_millis(4));
+
+        let server_addr = "127.0.0.1:12351".parse::<SocketAddr>().unwrap();
+        let client_addr = "127.0.0.1:12352".parse::<SocketAddr>().unwrap();
+
+        // Start up a server and a client.
+        let mut server = Socket::bind_with_config(server_addr, config.clone()).unwrap();
+        let mut client = Socket::bind_with_config(client_addr, config.clone()).unwrap();
+
+        // Initiate a connection
+        client
+            .send(Packet::unreliable(server_addr, vec![0, 1, 2]))
+            .unwrap();
+
+        let now = Instant::now();
+        client.manual_poll(now);
+        server.manual_poll(now);
+
+        // Make sure the connection was successful on the server side
+        assert_eq!(server.recv().unwrap(), SocketEvent::Connect(client_addr));
+        assert_eq!(
+            server.recv().unwrap(),
+            SocketEvent::Packet(Packet::unreliable(client_addr, vec![0, 1, 2]))
+        );
+
+        // Acknowledge the client
+        // This way, the server also knows about the connection and sends heartbeats
+        server
+            .send(Packet::unreliable(client_addr, vec![]))
+            .unwrap();
+
+        server.manual_poll(now);
+        client.manual_poll(now);
+
+        // Make sure the connection was successful on the client side
+        assert_eq!(
+            client.recv().unwrap(),
+            SocketEvent::Packet(Packet::unreliable(server_addr, vec![]))
+        );
+
+        // Give time to send heartbeats
+        client.manual_poll(now + config.heartbeat_interval.unwrap());
+        server.manual_poll(now + config.heartbeat_interval.unwrap());
+
+        // Give time for timeouts to occur if no heartbeats were sent
+        client.manual_poll(now + config.idle_connection_timeout);
+        server.manual_poll(now + config.idle_connection_timeout);
+
+        // Assert that no disconnection events occurred
+        assert_eq!(client.recv(), None);
+        assert_eq!(server.recv(), None);
+    }
 
     fn create_test_packet(id: u8, addr: &str) -> Packet {
         let payload = vec![id];
@@ -801,6 +899,9 @@ mod tests {
 
     #[test]
     fn multiple_sends_should_start_sending_dropped() {
+        const LOCAL_ADDR: &str = "127.0.0.1:13000";
+        const REMOTE_ADDR: &str = "127.0.0.1:14000";
+
         // Start up a server and a client.
         let mut server = Socket::bind(REMOTE_ADDR.parse::<SocketAddr>().unwrap()).unwrap();
         let mut client = Socket::bind(LOCAL_ADDR.parse::<SocketAddr>().unwrap()).unwrap();

--- a/src/packet/enums.rs
+++ b/src/packet/enums.rs
@@ -88,6 +88,8 @@ pub enum PacketType {
     Packet = 0,
     /// Fragment of a full packet
     Fragment = 1,
+    /// Heartbeat packet
+    Heartbeat = 2,
 }
 
 impl EnumConverter for PacketType {
@@ -104,6 +106,7 @@ impl TryFrom<u8> for PacketType {
         match value {
             0 => Ok(PacketType::Packet),
             1 => Ok(PacketType::Fragment),
+            2 => Ok(PacketType::Heartbeat),
             _ => Err(ErrorKind::DecodingError(DecodingErrorKind::PacketType)),
         }
     }
@@ -152,9 +155,10 @@ mod tests {
     }
 
     #[test]
-    fn assure_parsing_packet_id() {
+    fn assure_parsing_packet_type() {
         let packet = PacketType::Packet;
         let fragment = PacketType::Fragment;
+        let heartbeat = PacketType::Heartbeat;
         assert_eq!(
             PacketType::Packet,
             PacketType::try_from(packet.to_u8()).unwrap()
@@ -162,6 +166,10 @@ mod tests {
         assert_eq!(
             PacketType::Fragment,
             PacketType::try_from(fragment.to_u8()).unwrap()
+        );
+        assert_eq!(
+            PacketType::Heartbeat,
+            PacketType::try_from(heartbeat.to_u8()).unwrap()
         );
     }
 }

--- a/src/packet/header/standard_header.rs
+++ b/src/packet/header/standard_header.rs
@@ -17,7 +17,7 @@ pub struct StandardHeader {
 }
 
 impl StandardHeader {
-    /// Create new heartbeat header.
+    /// Create new header.
     pub fn new(
         delivery_guarantee: DeliveryGuarantee,
         ordering_guarantee: OrderingGuarantee,
@@ -51,6 +51,11 @@ impl StandardHeader {
     #[cfg(test)]
     pub fn packet_type(&self) -> PacketType {
         self.packet_type
+    }
+
+    /// Returns true if the packet is a heartbeat packet, false otherwise
+    pub fn is_heartbeat(&self) -> bool {
+        self.packet_type == PacketType::Heartbeat
     }
 
     /// Returns true if the packet is a fragment, false if not


### PR DESCRIPTION
Make sure that connections don't time out if we don't want them to, by
regularly sending special, empty "heartbeat" packets on connections that we
have not sent on for some time.

These heartbeats have the new packet type `PacketType::Heartbeat`, which makes it possible to differentiate them from empty packets sent by a user.

The heartbeat interval can be configured and disabled/enabled via `Config::heartbeat_interval`.

~~Note: Currently these heartbeats can not be explicity disabled (but you can set a very long heartbeat interval), but that should not be hard to add, if desired.~~ Edit: Heartbeats can now be disabled.