### PR TITLE
tests: Add missing asserts

### DIFF
--- a/src/infrastructure/arranging/ordering.rs
+++ b/src/infrastructure/arranging/ordering.rs
@@ -347,9 +347,9 @@ mod tests {
                 stub_packet1
             );
 
-            stream.arrange(4, stub_packet4.clone()).is_none();
-            stream.arrange(5, stub_packet5.clone()).is_none();
-            stream.arrange(3, stub_packet3.clone()).is_none();
+            assert![stream.arrange(4, stub_packet4.clone()).is_none()];
+            assert![stream.arrange(5, stub_packet5.clone()).is_none()];
+            assert![stream.arrange(3, stub_packet3.clone()).is_none()];
         }
         {
             let mut iterator = stream.iter_mut();

--- a/src/packet/header/acked_packet_header.rs
+++ b/src/packet/header/acked_packet_header.rs
@@ -85,7 +85,7 @@ mod tests {
     fn serialize() {
         let mut buffer = Vec::new();
         let header = AckedPacketHeader::new(1, 2, 3);
-        header.parse(&mut buffer).is_ok();
+        assert![header.parse(&mut buffer).is_ok()];
 
         assert_eq!(buffer[1], 1);
         assert_eq!(buffer[3], 2);

--- a/src/packet/header/arranging_header.rs
+++ b/src/packet/header/arranging_header.rs
@@ -74,7 +74,7 @@ mod tests {
     fn serialize() {
         let mut buffer = Vec::new();
         let header = ArrangingHeader::new(1, 2);
-        header.parse(&mut buffer).is_ok();
+        assert![header.parse(&mut buffer).is_ok()];
 
         assert_eq!(buffer[1], 1);
         assert_eq!(buffer[2], 2);

--- a/src/packet/header/fragment_header.rs
+++ b/src/packet/header/fragment_header.rs
@@ -83,7 +83,7 @@ mod tests {
     fn serialize() {
         let mut buffer = Vec::new();
         let header = FragmentHeader::new(1, 2, 3);
-        header.parse(&mut buffer).is_ok();
+        assert![header.parse(&mut buffer).is_ok()];
 
         assert_eq!(buffer[1], 1);
         assert_eq!(buffer[2], 2);

--- a/src/packet/header/standard_header.rs
+++ b/src/packet/header/standard_header.rs
@@ -126,7 +126,7 @@ mod tests {
             OrderingGuarantee::Sequenced(None),
             PacketType::Packet,
         );
-        header.parse(&mut buffer).is_ok();
+        assert![header.parse(&mut buffer).is_ok()];
 
         // [0 .. 3] protocol version
         assert_eq!(buffer[2], PacketType::Packet.to_u8());


### PR DESCRIPTION
Some asserts were missing on `is_ok` and `is_none` statements. This patch adds those asserts.