### PR TITLE
Fix ordering arranging handler for >65536 packets

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -185,6 +185,6 @@ mod tests {
 
     #[test]
     fn able_to_box_errors() {
-        let _: Box<Error> = Box::new(ErrorKind::CouldNotReadHeader("".into()));
+        let _: Box<dyn Error> = Box::new(ErrorKind::CouldNotReadHeader("".into()));
     }
 }

--- a/src/infrastructure/arranging/ordering.rs
+++ b/src/infrastructure/arranging/ordering.rs
@@ -244,6 +244,7 @@ impl<T> Arranging for OrderingStream<T> {
     ) -> Option<Self::ArrangingItem> {
         if incoming_offset == self.expected_index {
             self.expected_index += 1;
+            self.expected_index %= u16::max_value() as usize + 1;
             Some(item)
         } else if incoming_offset > self.expected_index {
             self.storage.insert(incoming_offset, item);

--- a/src/infrastructure/arranging/ordering.rs
+++ b/src/infrastructure/arranging/ordering.rs
@@ -234,7 +234,7 @@ impl<T> Arranging for OrderingStream<T> {
     /// This can only happen in cases where we have a duplicated package. Again we don't give anything back.
     ///
     /// # Remark
-    /// - When we receive an item there is a possibility that a gab is filled and one or more items will could be returned.
+    /// - When we receive an item there is a possibility that a gap is filled and one or more items will could be returned.
     ///   You should use the `iter_mut` instead for reading the items in order.
     ///   However the item given to `arrange` will be returned directly when it matches the `expected_index`.
     fn arrange(

--- a/src/net/socket.rs
+++ b/src/net/socket.rs
@@ -593,7 +593,7 @@ mod tests {
         server.forget_all_incoming_packets();
 
         // Send a packet that the server receives
-        for id in 0..36 {
+        for id in 0..35 {
             client
                 .send(create_ordered_packet(id, "127.0.0.1:12333"))
                 .unwrap();

--- a/src/net/virtual_connection.rs
+++ b/src/net/virtual_connection.rs
@@ -680,7 +680,15 @@ mod tests {
                 PAYLOAD.to_vec(),
                 Some(1),
             ))),
-            1,
+            0,
+        );
+
+        assert_incoming_with_order(
+            DeliveryGuarantee::Reliable,
+            OrderingGuarantee::Ordered(Some(1)),
+            &mut connection,
+            Err(TryRecvError::Empty),
+            2,
         );
 
         assert_incoming_with_order(
@@ -695,20 +703,12 @@ mod tests {
             DeliveryGuarantee::Reliable,
             OrderingGuarantee::Ordered(Some(1)),
             &mut connection,
-            Err(TryRecvError::Empty),
-            4,
-        );
-
-        assert_incoming_with_order(
-            DeliveryGuarantee::Reliable,
-            OrderingGuarantee::Ordered(Some(1)),
-            &mut connection,
             Ok(SocketEvent::Packet(Packet::reliable_ordered(
                 get_fake_addr(),
                 PAYLOAD.to_vec(),
                 Some(1),
             ))),
-            2,
+            1,
         );
     }
 
@@ -752,7 +752,7 @@ mod tests {
                 PAYLOAD.to_vec(),
                 Some(1),
             ))),
-            1,
+            0,
         );
     }
 


### PR DESCRIPTION
The arranging handler would not reset the value of the expecting index back to 0 which caused the case of having over 2**16 packets to simply be ignored.