### PR TITLE
Sequenced loop u16

### DIFF
--- a/src/net/socket.rs
+++ b/src/net/socket.rs
@@ -618,11 +618,14 @@ mod tests {
 
     #[test]
     fn do_not_duplicate_sequenced_packets_when_received() {
-        let server_addr = "127.0.0.1:12325".parse::<SocketAddr>().unwrap();
-        let client_addr = "127.0.0.1:12326".parse::<SocketAddr>().unwrap();
+        let mut config = Config::default();
 
-        let mut server = Socket::bind(server_addr).unwrap();
-        let mut client = Socket::bind(client_addr).unwrap();
+        let mut client = Socket::bind_any_with_config(config.clone()).unwrap();
+        config.blocking_mode = true;
+        let mut server = Socket::bind_any_with_config(config).unwrap();
+
+        let server_addr = server.local_addr().unwrap();
+        let client_addr = client.local_addr().unwrap();
 
         let time = Instant::now();
 
@@ -631,9 +634,8 @@ mod tests {
                 .send(Packet::reliable_sequenced(server_addr, vec![id], None))
                 .unwrap();
             client.manual_poll(time);
+            server.manual_poll(time);
         }
-
-        server.manual_poll(time);
 
         let mut seen = HashSet::new();
 

--- a/src/net/virtual_connection.rs
+++ b/src/net/virtual_connection.rs
@@ -139,17 +139,16 @@ impl VirtualConnection {
                         );
 
                         if let OrderingGuarantee::Ordered(stream_id) = ordering_guarantee {
-                            let item_identifier = if let Some(item_identifier) =
-                                last_item_identifier
-                            {
-                                item_identifier
-                            } else {
-                                self.ordering_system
-                                    .get_or_create_stream(
-                                        stream_id.unwrap_or(DEFAULT_ORDERING_STREAM),
-                                    )
-                                    .new_item_identifier() as u16
-                            };
+                            let item_identifier =
+                                if let Some(item_identifier) = last_item_identifier {
+                                    item_identifier
+                                } else {
+                                    self.ordering_system
+                                        .get_or_create_stream(
+                                            stream_id.unwrap_or(DEFAULT_ORDERING_STREAM),
+                                        )
+                                        .new_item_identifier()
+                                };
 
                             item_identifier_value = Some(item_identifier);
 
@@ -157,17 +156,16 @@ impl VirtualConnection {
                         };
 
                         if let OrderingGuarantee::Sequenced(stream_id) = ordering_guarantee {
-                            let item_identifier = if let Some(item_identifier) =
-                                last_item_identifier
-                            {
-                                item_identifier
-                            } else {
-                                self.sequencing_system
-                                    .get_or_create_stream(
-                                        stream_id.unwrap_or(DEFAULT_SEQUENCING_STREAM),
-                                    )
-                                    .new_item_identifier() as u16
-                            };
+                            let item_identifier =
+                                if let Some(item_identifier) = last_item_identifier {
+                                    item_identifier
+                                } else {
+                                    self.sequencing_system
+                                        .get_or_create_stream(
+                                            stream_id.unwrap_or(DEFAULT_SEQUENCING_STREAM),
+                                        )
+                                        .new_item_identifier()
+                                };
 
                             item_identifier_value = Some(item_identifier);
 


### PR DESCRIPTION
    sequencing: Loop the indexing method

    Sending over 65536 packets would previously just saturate the top_index
    which caused it to not accept any more packets. This patch shortens the
    sequence acceptance by half but always loops around the max u16 value.

    This means that at top_index = 0, all sequenced packets 0-32768 are
    accepted, while at top_index = 50000, all sequenced packets 50000-65535
    and 0-17233 will be accepted.

