### PR TITLE
Disconnect the connection after sending N un-acked packets

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -48,6 +48,12 @@ pub struct Config {
     ///
     /// Value that specifies how long we should block polling for socket events, in milliseconds. Defaults to `1ms`.
     pub socket_polling_timeout: Option<Duration>,
+    /// The maximum amount of reliable packets in flight on this connection before we drop the
+    /// connection.
+    ///
+    /// When we send a reliable packet, it is stored locally until an acknowledgement comes back to
+    /// us, if that store grows to a size
+    pub max_packets_in_flight: u16,
 }
 
 impl Default for Config {
@@ -65,6 +71,7 @@ impl Default for Config {
             rtt_max_value: 250,
             socket_event_buffer_size: 1024,
             socket_polling_timeout: Some(Duration::from_millis(1)),
+            max_packets_in_flight: 512,
         }
     }
 }

--- a/src/infrastructure/acknowledgment.rs
+++ b/src/infrastructure/acknowledgment.rs
@@ -31,6 +31,11 @@ impl AcknowledgmentHandler {
         }
     }
 
+    /// Get the current number of not yet acknowledged packets
+    pub fn packets_in_flight(&self) -> u16 {
+        self.sent_packets.len() as u16
+    }
+
     /// Returns the next sequence number to send.
     pub fn local_sequence_num(&self) -> SequenceNumber {
         self.sequence_number

--- a/src/net/connection.rs
+++ b/src/net/connection.rs
@@ -67,6 +67,15 @@ impl ActiveConnections {
             .collect()
     }
 
+    /// Get a list of addresses of dead connections
+    pub fn dead_connections(&mut self) -> Vec<SocketAddr> {
+        self.connections
+            .iter()
+            .filter(|(_, connection)| connection.should_be_dropped())
+            .map(|(address, _)| *address)
+            .collect()
+    }
+
     /// Check for and return `VirtualConnection`s which have not sent anything for a duration of at least `heartbeat_interval`.
     pub fn heartbeat_required_connections(
         &mut self,

--- a/src/net/virtual_connection.rs
+++ b/src/net/virtual_connection.rs
@@ -56,6 +56,11 @@ impl VirtualConnection {
         }
     }
 
+    /// Determine if this connection should be dropped due to its state
+    pub fn should_be_dropped(&self) -> bool {
+        self.acknowledge_handler.packets_in_flight() > self.config.max_packets_in_flight
+    }
+
     /// Returns a [Duration] representing the interval since we last heard from the client
     pub fn last_heard(&self, time: Instant) -> Duration {
         // TODO: Replace with saturating_duration_since once it becomes stable.


### PR DESCRIPTION
The connection is disconnected if we have N packets-in-flight
simultaneously. Under normal usage we expect packets to be acked
regularly so that our packets-in-flight size is relatively small.