### PR TITLE
[ordered]: Fix sending acks for ordered fragmented packets

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -128,6 +128,10 @@ pub enum FragmentErrorKind {
     FragmentWithUnevenNumberOfFragemts,
     /// Fragment we expected to be able to find we couldn't
     CouldNotFindFragmentById,
+    /// Multiple ack headers sent with these fragments
+    MultipleAckHeaders,
+    /// Ack header is missing from a finished set of fragments
+    MissingAckHeader,
 }
 
 impl Display for FragmentErrorKind {
@@ -150,6 +154,14 @@ impl Display for FragmentErrorKind {
             FragmentErrorKind::CouldNotFindFragmentById => write!(
                 fmt,
                 "The fragment supposed to be in a the cache but it was not found."
+            ),
+            FragmentErrorKind::MultipleAckHeaders => write!(
+                fmt,
+                "The fragment contains an ack header but a previous ack header has already been registered."
+            ),
+            FragmentErrorKind::MissingAckHeader => write!(
+                fmt,
+                "No ack headers were registered with any of the fragments."
             ),
         }
     }

--- a/src/net/virtual_connection.rs
+++ b/src/net/virtual_connection.rs
@@ -293,11 +293,12 @@ impl VirtualConnection {
                     if let Ok((fragment_header, acked_header)) = packet_reader.read_fragment() {
                         let payload = packet_reader.read_payload();
 
-                        match self
-                            .fragmentation
-                            .handle_fragment(fragment_header, &payload)
-                        {
-                            Ok(Some(payload)) => {
+                        match self.fragmentation.handle_fragment(
+                            fragment_header,
+                            &payload,
+                            acked_header,
+                        ) {
+                            Ok(Some((payload, acked_header))) => {
                                 Self::queue_packet(
                                     sender,
                                     payload.into_boxed_slice(),
@@ -305,20 +306,18 @@ impl VirtualConnection {
                                     header.delivery_guarantee(),
                                     OrderingGuarantee::None,
                                 )?;
+
+                                self.congestion_handler
+                                    .process_incoming(acked_header.sequence());
+                                self.acknowledge_handler.process_incoming(
+                                    acked_header.sequence(),
+                                    acked_header.ack_seq(),
+                                    acked_header.ack_field(),
+                                );
                             }
                             Ok(None) => return Ok(()),
                             Err(e) => return Err(e),
                         };
-
-                        if let Some(acked_header) = acked_header {
-                            self.congestion_handler
-                                .process_incoming(acked_header.sequence());
-                            self.acknowledge_handler.process_incoming(
-                                acked_header.sequence(),
-                                acked_header.ack_seq(),
-                                acked_header.ack_field(),
-                            );
-                        }
                     }
                 } else {
                     let acked_header = packet_reader.read_acknowledge_header()?;
@@ -463,10 +462,10 @@ mod tests {
 
         let standard_header = [protocol_version, vec![1, 1, 2]].concat();
 
-        let acked_header = vec![1, 0, 0, 2, 0, 0, 0, 3];
-        let first_fragment = vec![0, 1, 1, 3];
-        let second_fragment = vec![0, 1, 2, 3];
-        let third_fragment = vec![0, 1, 3, 3];
+        let acked_header = vec![0, 0, 0, 4, 0, 0, 255, 255, 0, 0, 0, 0];
+        let first_fragment = vec![0, 0, 1, 4];
+        let second_fragment = vec![0, 0, 2, 4];
+        let third_fragment = vec![0, 0, 3, 4];
 
         let (tx, rx) = unbounded::<SocketEvent>();
 

--- a/src/sequence_buffer.rs
+++ b/src/sequence_buffer.rs
@@ -69,12 +69,14 @@ impl<T: Clone + Default> SequenceBuffer<T> {
     }
 
     /// Removes an entry from the sequence buffer
-    pub fn remove(&mut self, sequence_num: SequenceNumber) {
+    pub fn remove(&mut self, sequence_num: SequenceNumber) -> Option<T> {
         if self.exists(sequence_num) {
             let index = self.index(sequence_num);
-            self.entries[index] = T::default();
+            let value = std::mem::replace(&mut self.entries[index], T::default());
             self.entry_sequences[index] = None;
+            return Some(value);
         }
+        None
     }
 
     // Advances the sequence number while removing older entries.

--- a/src/sequence_buffer/reassembly_data.rs
+++ b/src/sequence_buffer/reassembly_data.rs
@@ -1,4 +1,5 @@
 use crate::net::constants::MAX_FRAGMENTS_DEFAULT;
+use crate::packet::header::AckedPacketHeader;
 use crate::packet::SequenceNumber;
 
 #[derive(Clone)]
@@ -9,6 +10,7 @@ pub struct ReassemblyData {
     pub num_fragments_total: u8,
     pub buffer: Vec<u8>,
     pub fragments_received: [bool; MAX_FRAGMENTS_DEFAULT as usize],
+    pub acked_header: Option<AckedPacketHeader>,
 }
 
 impl ReassemblyData {
@@ -19,6 +21,7 @@ impl ReassemblyData {
             num_fragments_total,
             buffer: Vec::with_capacity(prealloc),
             fragments_received: [false; MAX_FRAGMENTS_DEFAULT as usize],
+            acked_header: None,
         }
     }
 }
@@ -31,6 +34,7 @@ impl Default for ReassemblyData {
             num_fragments_total: 0,
             buffer: Vec::with_capacity(1024),
             fragments_received: [false; MAX_FRAGMENTS_DEFAULT as usize],
+            acked_header: None,
         }
     }
 }


### PR DESCRIPTION
The packets would not be acked because only the first fragment had an
ack header, and that ack header would only be used after the last
fragment had been received - while the header had not been stored.

This patch stores that header inside the reassembly data so it can later
be used when returning the final packet.