### PR TITLE
[ordered]: Ensure we don't read out-of-bounds on malformed headers

### DIFF
--- a/src/infrastructure/fragmenter.rs
+++ b/src/infrastructure/fragmenter.rs
@@ -120,6 +120,10 @@ impl Fragmentation {
                 Err(FragmentErrorKind::FragmentWithUnevenNumberOfFragemts)?
             }
 
+            if usize::from(fragment_header.id()) >= reassembly_data.fragments_received.len() {
+                Err(FragmentErrorKind::ExceededMaxFragments)?;
+            }
+
             if reassembly_data.fragments_received[usize::from(fragment_header.id())] {
                 Err(FragmentErrorKind::AlreadyProcessedFragment)?
             }

--- a/src/net/virtual_connection.rs
+++ b/src/net/virtual_connection.rs
@@ -783,6 +783,40 @@ mod tests {
         );
     }
 
+    #[test]
+    fn ensure_input_header_data_does_not_access_out_of_bounds() {
+        let mut protocol_version = Vec::new();
+        protocol_version
+            .write_u16::<BigEndian>(ProtocolVersion::get_crc16())
+            .unwrap();
+
+        let standard_header = [protocol_version, vec![1, 1, 2]].concat();
+
+        let acked_header = vec![0, 0, 255, 4, 0, 0, 255, 255, 0, 0, 0, 0];
+
+        let (tx, rx) = unbounded::<SocketEvent>();
+
+        use crate::error::{ErrorKind, FragmentErrorKind};
+
+        let mut connection = create_virtual_connection();
+        let result = connection.process_incoming(
+            [standard_header.as_slice(), acked_header.as_slice()]
+                .concat()
+                .as_slice(),
+            &tx,
+            Instant::now(),
+        );
+
+        match result {
+            Err(ErrorKind::FragmentError(FragmentErrorKind::ExceededMaxFragments)) => {
+                // Ok
+            }
+            _ => {
+                panic!["Supposed to get a fragment error"];
+            }
+        }
+    }
+
     /// ======= helper functions =========
     fn create_virtual_connection() -> VirtualConnection {
         VirtualConnection::new(get_fake_addr(), &Config::default(), Instant::now())


### PR DESCRIPTION
Malformed headers can read out of bounds if the input isn't checked.

Suggest that we fuzz sending arbitrary data to uncover more flaws.