### PR TITLE
Removed SendError that can never occur.

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -7,11 +7,10 @@ on:
     
 jobs:
   test:
-    name: Test on node ${{ matrix.node_version }} and ${{ matrix.os }}
+    name: Running on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node_version: [8, 10, 12]
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,0 +1,21 @@
+name: Rust
+
+on:
+  push:
+    branches:
+    - master
+    
+jobs:
+  test:
+    name: Test on node ${{ matrix.node_version }} and ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        node_version: [8, 10, 12]
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+    steps:
+    - uses: actions/checkout@v1
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose    

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laminar"
-version = "0.3.1"
+version = "0.3.2"
 authors = [
     "Lucio Franco <luciofranco14@gmail.com>",
     "Fletcher Haynes <fletcher@capitalprawn.com>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,23 +20,23 @@ autobenches = false
 edition = "2018"
 
 [dependencies]
-byteorder = "1.2"
+byteorder = "1.3"
 crc = "1.8"
 crossbeam-channel = "0.3"
-lazy_static = "1.1"
+lazy_static = "1.4"
 log = "0.4"
-mio = "0.6"
-rand = "0.6"
-rand_pcg = "0.1"
-clap = { version = "2.32", features = ["yaml"], optional = true }
+rand = "0.7"
+rand_pcg = "0.2"
+
+clap = { version = "2.33", features = ["yaml"], optional = true }
 env_logger = { version = "0.6", optional = true }
 
 [dev-dependencies]
-bincode = "1.0"
-criterion = "0.2"
+bincode = "1.1.4"
+criterion = "0.3"
 serde = "1.0"
 serde_derive = "1.0"
-quickcheck = "0.8"
+quickcheck = "0.9"
 quickcheck_macros = "0.8"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laminar"
-version = "0.3.0"
+version = "0.3.1"
 authors = [
     "Lucio Franco <luciofranco14@gmail.com>",
     "Fletcher Haynes <fletcher@capitalprawn.com>",

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ and provides a lightweight, message-based interface which provides certain guara
 
 Laminar was designed to be used within the [Amethyst][amethyst] game engine but is usable without it.
 
+If you are new to laminar or networking in general, We strongly recommend taking a look at the [laminar book][book]
+
 [amethyst]: https://github.com/amethyst/amethyst
 
 # Concepts
@@ -35,7 +37,6 @@ For more information, read the projects [README.md][readme], [book][book], [docs
 [book]: https://amethyst.github.io/laminar/docs/index.html
 [docs]: https://docs.rs/laminar/
 [examples]: https://github.com/amethyst/laminar/tree/master/examples
-
 [amethyst]: https://github.com/amethyst/amethyst
 
 ## Table of contents:
@@ -61,6 +62,9 @@ These are the features this crate provides:
 - RTT Estimation
 - Link conditioner to simulate packet loss and latency
 - Well-tested by integration and unit tests
+- Basic DoS mitigation
+- High Timing control
+- Can be used by multiple threads (Sender, Receiver)
 
 ## Getting Stated
 Add the laminar package to your `Cargo.toml` file.

--- a/README.md
+++ b/README.md
@@ -52,26 +52,36 @@ For more information, read the projects [README.md][readme], [book][book], [docs
 ## Features
 These are the features this crate provides:
 
-- UDP-based Protocol
-- Connection Tracking
-- Automatic Fragmentation
-- Reliability Options: Unreliable and Reliable
-- Arranging Options: Sequenced, Unordered, and Ordered.
-- Arranging Streams
-- Protocol Versioning
-- RTT Estimation
-- Link conditioner to simulate packet loss and latency
-- Well-tested by integration and unit tests
-- Basic DoS mitigation
-- High Timing control
-- Can be used by multiple threads (Sender, Receiver)
+* [x] Fragmentation
+* [x] Unreliable packets
+* [x] Unreliable sequenced packets
+* [x] Reliable unordered packets
+* [x] Reliable ordered packets
+* [x] Reliable sequenced packets
+* [x] Fragmentation
+* [x] Rtt estimations
+* [x] Protocol version monitoring
+* [x] Basic connection management
+* [x] Heartbeat
+* [x] Basic DoS mitigation
+* [x] High Timing control
+* [x] Protocol Versioning
+* [x] Well-tested by integration and unit tests
+* [x] Can be used by multiple threads (Sender, Receiver)
+
+### Planned
+
+* [ ] Handshake Protocol
+* [ ] Advanced Connection Management
+* [ ] Cryptography
+* [ ] Congestion Control
 
 ## Getting Stated
 Add the laminar package to your `Cargo.toml` file.
 
 ```toml
 [dependencies]
-laminar = "0.3.0"
+laminar = "0.3"
 ```
 
 ### Useful Links

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 This document contains information about the releases of this crate.
 
+## [0.3.2] - 2019-09-24
+- Acknowledgement is sent after all fragments arrived
+- Don't read out-of-bounds on malformed headers 
+
 ## [0.3.1] - 2019-09-16
 - Documentation improvements (docs, book, readme)
 - Allow a Socket to be in blocking mode

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 This document contains information about the releases of this crate.
+
+## [0.3.1] - 2019-09-16
+- Documentation improvements (docs, book, readme)
+- Allow a Socket to be in blocking mode
+- Default heartbeat functionality
+- Series of patches and bug-fixes for ordering, sequencing. 
+- Disconnect the connection after sending N un-acked packets
+- Dependency maintenance (removed and increased versions)
+- A lot of new unit tests
+
 ## [0.3.0] - 2019-06-29
 - Moved the packet sender and event receiver into socket struct
 - Exposed internal SocketAddr

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -4,15 +4,24 @@ These are all the features we have and don't have.
 
 * [x] Fragmentation
 * [x] Unreliable packets
+* [x] Unreliable sequenced packets
 * [x] Reliable unordered packets
+* [x] Reliable ordered packets
+* [x] Reliable sequenced packets
 * [x] Fragmentation
 * [x] Rtt estimations
 * [x] Protocol version monitoring
-* [x] Virtual connection management
+* [x] Basic connection management
+* [x] Heartbeat
+* [x] Basic DoS mitigation
+* [x] High Timing control
+* [x] Protocol Versioning
+* [x] Well-tested by integration and unit tests
+* [x] Can be used by multiple threads (Sender, Receiver)
 
 ## Planned
 
-* [ ] Reliable Ordered packets
-* [ ] Unreliable Ordered packets
-* [ ] Sequenced packets
+* [ ] Handshake Protocol
+* [ ] Advanced Connection Management
 * [ ] Cryptography
+* [ ] Congestion Control

--- a/docs/md_book/src/SUMMARY.md
+++ b/docs/md_book/src/SUMMARY.md
@@ -1,11 +1,13 @@
 # Summary
 
 - [Intro](intro.md)
+- [Important Notices](important.md)
 - [Protocols](protocols.md)
+- [Heartbeat](heartbeat.md)
+- [Fragmentation](fragmentation.md)
+- [Reliability](reliability/basics.md)
+    - [Basics](reliability/basics.md)
+    - [Reliability](reliability/reliability.md)
+    - [Ordering](reliability/ordering.md)
 - [Congestion Avoidance](congestion_avoidence/congestion_avoidance.md)
     - [Whit RTT](congestion_avoidence/rtt.md)
-    - [Whit Packet loss](congestion_avoidence/packet_loss.md)
-- [Fragmentation](fragmentation.md)
-- [Reliability](reliability/basicis.md)
-    - [Basics](reliability/basicis.md)
-    - [Reliability](reliability/reliability.md)

--- a/docs/md_book/src/congestion_avoidence/congestion_avoidance.md
+++ b/docs/md_book/src/congestion_avoidence/congestion_avoidance.md
@@ -6,5 +6,6 @@ We need to try to avoid sending too much bandwidth in the first place, and then 
 
 There are a few methods we can implement to defeat congestion.
 1. With [RTT](./rtt.md)
-2. With packet loss
+2. With packet loss [TODO]
 
+Unfortunately, congestion avoidance has not yet been implemented for laminar. 

--- a/docs/md_book/src/congestion_avoidence/packet_loss.md
+++ b/docs/md_book/src/congestion_avoidence/packet_loss.md
@@ -1,1 +1,0 @@
-# Whit Packet loss

--- a/docs/md_book/src/fragmentation.md
+++ b/docs/md_book/src/fragmentation.md
@@ -18,6 +18,13 @@ If you really want to send large amounts of data over the line go for TCP instea
 When sending small packets with the size of about 4000 bytes (4 fragments) this method will work fine. And won't probably cause any problems. 
 We are planning to support also [sending larger packets](https://gafferongames.com/post/sending_large_blocks_of_data/) with acknowledgments.
 
+## Laminar's implementation
+Laminar fragments your packet if it exceeds the [fragment size](https://github.com/amethyst/laminar/blob/master/src/config.rs#L29).
+
+Fragments of a large packet are not yet acknowledged This is a problem if you want to send too large files. 
+If you want to send really large files, I advise you to split up your package and send it in pieces with the option 'reliable ordered'. 
+In the future laminar will be able to send large packets with acknowledgement.
+
 ## Interesting Reads
 - [Gaffer about Fragmentation](https://gafferongames.com/post/packet_fragmentation_and_reassembly/)
 - [Wikipedia](https://en.wikipedia.org/wiki/IP_fragmentation)

--- a/docs/md_book/src/heartbeat.md
+++ b/docs/md_book/src/heartbeat.md
@@ -1,0 +1,39 @@
+## Heartbeat
+Laminar offers the possibility to keep the connection with a client open. 
+This is done with heartbeat packets. 
+This option is enabled by default.
+The behavior of the heart beat can be changed in the [configuration](https://github.com/amethyst/laminar/pull/224). 
+It can also be disabled.
+
+A client is considered a connection when it sends a packet. 
+If the client does not send a packet for x seconds, laminar sees this as an idling connection, and it is removed as an active connection.
+When this happens, the following data is removed: 
+
+1) the reliability data such as acknowledged packets 
+2) the buffers that keep track of the ordering/sequencing. 
+3) the RTT counter
+4) fragmentation data
+
+Losing this data from the memory is often undesirable.
+Therefore, it is important to have a consistent flow of packets between the two endpoints which will prevent disconnection of the client.
+The time before the client is disconnected can be changed in the [configuration](https://github.com/amethyst/laminar/blob/master/src/config.rs#L10).
+
+## Why a heartbeat?
+With game networking for fast-paced FPS games, you have to deal with a lot of data that has to go from point A to B.
+We are talking about numbers of 20/30/60 hz. 
+Laminar is based and optimized for the situation where a consistent flow of packets from the server to the client and from the client to the server that are being sent.
+In a game, where everything runs at milliseconds and speed is important, you need fast communication and multiple updates per seconds.
+
+What are those scenarios and how can I know if laminar is useful for my use case?
+You can think of input synchronization, location updates, state updates, events, etc.  
+Let's zoom in on input synchronization of an FPS game. 
+The client sends the packages, the server receives it, validates it, and sends an update to all other clients. 
+In an FPS game, a lot of input is shared, and it's not a strange idea for a client to share its input and receive updates 60 times a second.   
+Laminar is based on this idea, and is optimized for it. 
+When you are sending packets once a second, laminar might not be the best solution here. And your probably going to do fine with TCP. 
+
+To add to this, note that clients will be seen as 'disconnected' if they don't send packets for some duration, this duration can be found in the [configuration][config]. 
+When there is a scenario's that you are sending packets less frequent, laminar has the option to keep the connection alive by sending an heath beat message at a configurable interval.
+
+
+- [Original PR](https://github.com/amethyst/laminar/pull/224)

--- a/docs/md_book/src/important.md
+++ b/docs/md_book/src/important.md
@@ -1,0 +1,25 @@
+## Some Important Notices
+
+There are a few important things you need to know in order to use laminar appropriately.
+If you do not follow these rules, then it is possible that either laminar is not suitable for your use case, and/or it will not work as expected.
+
+1. Packet Consistency
+    Make sure that the client and the server send messages to each other at a consistent rate, e.g. 30Hz. If you don't do this,
+    the connection may break, and cause the reliability and order aspect of laminar not to work. For more information checkout [heartbeat implementation](heartbeat.md).
+
+2. Reliability, transferring big data
+    Laminar is not designed for transferring large files.
+    The [fragments](fragmentation.md) of the fragmented packet will not be acknowledged. 
+    So if a fragment is lost, the whole packet is lost. Although this will be improved in the future, for more information checkout [fragmentation](fragmentation.md) and [reliability](reliability/basics.md).
+3. DDOS Protection
+
+    DDOS protection ensures that a client that sends something is not simply identified as a trustworthy connection. 
+    If this were the case, someone could easily spoof packets and DDOS our server with new connections.
+
+    **Make sure the server responds to a message from the client. Only if the server responds, will the connection to the client be tracked.**
+    
+    In the future we want to have a [handshaking process](https://github.com/amethyst/laminar/issues/156) to simplify this process.
+
+
+[config]: https://github.com/amethyst/laminar/blob/master/src/config.rs#L8
+[DDOS]: https://github.com/amethyst/laminar/issues/187

--- a/docs/md_book/src/important.md
+++ b/docs/md_book/src/important.md
@@ -3,23 +3,26 @@
 There are a few important things you need to know in order to use laminar appropriately.
 If you do not follow these rules, then it is possible that either laminar is not suitable for your use case, and/or it will not work as expected.
 
-1. Packet Consistency
-    Make sure that the client and the server send messages to each other at a consistent rate, e.g. 30Hz. If you don't do this,
-    the connection may break, and cause the reliability and order aspect of laminar not to work. For more information checkout [heartbeat implementation](heartbeat.md).
+1. Packet Consistency:
 
-2. Reliability, transferring big data
-    Laminar is not designed for transferring large files.
-    The [fragments](fragmentation.md) of the fragmented packet will not be acknowledged. 
-    So if a fragment is lost, the whole packet is lost. Although this will be improved in the future, for more information checkout [fragmentation](fragmentation.md) and [reliability](reliability/basics.md).
-3. DDOS Protection
+    Make sure that the client and the server send messages to each other at a consistent rate, i.e. 30Hz. If you don't do this,
+    the connection may close, or cause the reliability and order aspect of laminar to be laggy. For more information checkout [heartbeat implementation](heartbeat.md).
 
-    DDOS protection ensures that a client that sends something is not simply identified as a trustworthy connection. 
-    If this were the case, someone could easily spoof packets and DDOS our server with new connections.
+2. Reliability and transferring big data:
 
-    **Make sure the server responds to a message from the client. Only if the server responds, will the connection to the client be tracked.**
-    
+    Laminar is not designed for transferring large amounts of data.
+    The [fragments](fragmentation.md) of the fragmented packet will not be acknowledged.
+    So if a fragment is lost - the whole packet is lost. This will likely be improved in the future, for more information check out [fragmentation](fragmentation.md) and [reliability](reliability/basics.md).
+
+3. DoS Protection
+
+    DoS protection ensures that new clients are unable to use memory resources on the machine.
+    If this were the case, some malicious actor could easily spoof packets and DoS our server with new connections.
+
+    **Make sure to respond to a message from another endpoint. Only if we respond, will the connection to the endpoint be stored.**
+
     In the future we want to have a [handshaking process](https://github.com/amethyst/laminar/issues/156) to simplify this process.
 
 
 [config]: https://github.com/amethyst/laminar/blob/master/src/config.rs#L8
-[DDOS]: https://github.com/amethyst/laminar/issues/187
+[DoS]: https://github.com/amethyst/laminar/issues/187

--- a/docs/md_book/src/intro.md
+++ b/docs/md_book/src/intro.md
@@ -2,11 +2,11 @@
 
 ## Introduction
 
-Welcome! This book will teach you everything you need to know about of the networking in laminar.
+Welcome! This book will teach you everything you need to know about networking with Laminar.
 We will discuss important parts of network programming, why we made certain decisions and some explanations about networking concepts in general.
 
 Laminar is free and open source software, distributed under a dual license of [MIT][ml]
-and [Apache][al]. This means that the engine is given to you at no cost
+and [Apache][al]. This means that the engine is provided to you at no cost
 and its source code is completely yours to tinker with. The code is available on
 [GitHub][am]. Contributions and feature requests will always be welcomed!
 
@@ -15,9 +15,9 @@ and its source code is completely yours to tinker with. The code is available on
 [am]: https://github.com/amethyst/laminar/tree/master
 
 ## Motivation
-Laminar is fully written in Rust and therefore it has no garbage collector, no data-races, and memory safety. 
-That's why laminar is a good candidate to be a safe and better replacement for other reliable-UDP implementations.
-This library is written for use in the Amethyst game engine, however, we fully believe that this library can become an excellent reliable UDP implementation in its own right.
+Laminar is fully written in Rust and therefore has no garbage collector, no data-races, and is completely memory safe.
+That's why Laminar is a good candidate to be a safe and better replacement for other reliable-UDP implementations.
+This library is originally written for use in the Amethyst game engine, however, Laminar can operate fully without Amethyst.
 
 ## Similar Projects
 We used some inspiration from other similar projects.

--- a/docs/md_book/src/intro.md
+++ b/docs/md_book/src/intro.md
@@ -1,4 +1,4 @@
-#This book is still in development and is just a draft. And much needs to be changed.
+# This book is still in active development.
 
 ## Introduction
 
@@ -15,14 +15,23 @@ and its source code is completely yours to tinker with. The code is available on
 [am]: https://github.com/amethyst/laminar/tree/master
 
 ## Motivation
-some decisions about why we are working on this like the rust safety compared to other implementations out there etc. 
-And that there are not really good implementations yet which for fill all or needs.
+Laminar is fully written in Rust and therefore it has no garbage collector, no data-races, and memory safety. 
+That's why laminar is a good candidate to be a safe and better replacement for other reliable-UDP implementations.
+This library is written for use in the Amethyst game engine, however, we fully believe that this library can become an excellent reliable UDP implementation in its own right.
+
+## Similar Projects
+We used some inspiration from other similar projects.
+
+- [NetCode IO, C++ with Go, Rust, C# bindings](https://github.com/networkprotocol/netcode.io)
+- [RakNet, C++](https://github.com/SLikeSoft/SLikeNet)
+- [Steam Network Socket, , C++](https://github.com/ValveSoftware/GameNetworkingSockets)
+- [LiteNetLib, C#](https://github.com/RevenantX/LiteNetLib)
+- [ENet, C](http://enet.bespin.org/)
 
 ## Contributing
-
 We are always happy to welcome new contributors!
 
-If you want to contribute, or have questions, let us know either on [GitHub][db], or on [Discord][di].
+If you want to contribute, or have questions, let us know either on [GitHub][db], or on [Discord][di] (#net).
 
 [di]: https://discord.gg/amethyst
 [db]: https://github.com/amethyst/laminar/

--- a/docs/md_book/src/packet_header.md
+++ b/docs/md_book/src/packet_header.md
@@ -2,7 +2,7 @@
 In this topic we'll discuss the different headers we are pre-pending to the data sent via laminar.
 We use different headers in different scenario's, we do this to reduce the packet size. 
 
-Take a look over here: [image](LINK) for the complete design.
+Take a look over here: [image](/docs/technical/hearder_design.png) for the complete design.
 
 - `Standard header`
     

--- a/docs/md_book/src/protocols.md
+++ b/docs/md_book/src/protocols.md
@@ -41,7 +41,7 @@ Like IP, UDP is an unreliable protocol. In practice however, most packets that a
 ## Why UDP and not TCP | More
 Those of you familiar with TCP know that it already has its own concept of connection, reliability-ordering and congestion avoidance, so why are we rewriting our own mini version of TCP on top of UDP?
 
-The issue is that multilayer action games rely on a steady stream of packets sent at rates of 10 to 30 packets per second, and for the most part, the data contained in these packets is so time sensitive that only the most recent data is useful. 
+The issue is that multiplayer action games rely on a steady stream of packets sent at rates of 10 to 30 packets per second, and for the most part, the data contained in these packets is so time sensitive that only the most recent data is useful. 
 This includes data such as player inputs, the position, orientation and velocity of each player character, and the state of physics objects in the world.
 
 The problem with TCP is that it abstracts data delivery as a reliable ordered stream. Because of this, if a packet is lost, TCP has to stop and wait for that packet to be resent.

--- a/docs/md_book/src/protocols.md
+++ b/docs/md_book/src/protocols.md
@@ -21,7 +21,7 @@ The TCP protocol will also split up and reassemble packets if those are too larg
 **Characteristics**
 - Reliable
 - Ordered
-- Automatic [fragmentation](LINK) of packets
+- Automatic [fragmentation](fragmentation.md) of packets
 - Stream based
 - Control Flow ([Congestion Avoidance](congestion_avoidence/congestion_avoidance.md))
  

--- a/docs/md_book/src/reliability/basicis.md
+++ b/docs/md_book/src/reliability/basicis.md
@@ -1,1 +1,0 @@
-# Reliability

--- a/docs/md_book/src/reliability/basics.md
+++ b/docs/md_book/src/reliability/basics.md
@@ -1,0 +1,19 @@
+# Introduction
+The internet is a dangerous place, and before you know it your data is gone or your data arrives duplicated because your data is split up along the way to its final destination. 
+In order to have more control over the way in which the data is transported, we have invented protocols. 
+
+In this chapter we will consider how laminar gives you more control over the transport of data.
+
+## Important
+TCP is made for reliability and does this very well. 
+We have been asked many times by people why reliability does not work well or is slow in laminar.
+Important to know is that laminar has reliability as an option but is not focused on trying to be faster and better than TCP. 
+For fast-paced multiplayer online games, it is not desirable to use TCP because a delay in a packet can have a major impact on all subsequent packets.
+Reliability, after all, is less important for fast-paced FPS games; UDP. 
+TCP should be used when the need for reliability trumps the need for low latency
+That said, laminar will support acknowledgement of fragments in the future. Checkout [fragmentation](../fragmentation.md) for more info.
+
+- [Ordering](ordering.md)
+How can we control the way the data is ordered.
+- [Reliability](reliability.md)
+How can we control the arrival of our data.

--- a/docs/md_book/src/reliability/ordering.md
+++ b/docs/md_book/src/reliability/ordering.md
@@ -1,6 +1,8 @@
+## Arranging packets
+
 Laminar provides a way to arrange packets, over different streams.
 
-The above sentence contains a lot of important information, let us zoom a little more on the above sentence.
+The above sentence contains a lot of important information, let us zoom in a little more at the above sentence.
 
 ## Ordering VS Sequencing
 Let's define two concepts here:
@@ -9,23 +11,29 @@ _"Ordering: this is the process of putting something in a particular order."_ [2
 
 - Sequencing: Only the newest items will be passed trough e.g. `1,3,2,5,4` which results in `1,3,5`.
 - Ordering: All items are returned in order `1,3,2,5,4` which results in `1,2,3,4,5`.
+- Arranging: We call the process for ordering and sequencing 'arranging' of packets
+
+Due to the design of the internet, it is not always guaranteed that packets will arrive or that they will be received in the order they were sent.
+Fortunately, Laminar's implementation grants the ability to optionally specify how reliable and ordered (or not) the stream of packets is delivered to the client.
 
 ### How ordering works.
-Imagine we have this sequence: `1,5,4,2,3` and we want the user to eventually see: `1,2,3,4,5`.
+If we were to send the following packets: `1,2,3,4,5`, 
+but something happens on the internet which causes the packets to arrive at their final destination as: `1,5,4,2,3`, 
+then Laminar ensures that your packets arrive to the client as  `1,2,3,4,5`.
 
 ## Arranging Streams
 What are these 'arranging streams'?
 You can see 'arranging streams' as something to arrange packets that have no relationship at all with one another. 
 You could either arrange packets in order or in sequence.
 
-## Simple Example
+### Simple Example
 Think of a highway where you have several lanes where cars are driving.
 Because there are these lanes, cars can move on faster.
 For example, the cargo drivers drive on the right and the high-speed cars on the left.
-The cargo drivers have no influence on fast cars and vice versa.
+The cargo drivers do not influence fast cars and vice versa.
 
-## Real Example
-If a game developer wants to send data to a client, it could happen that he wants to send data either ordered, unordered or sequenced.
+### Real Example
+If a game developer wants to send data to a client, he might want to send data either ordered, unordered or sequenced.
 
 'Data' could be the following:
 1. Player movement, we want to order player movements because we don't want the player to glitch.
@@ -37,6 +45,19 @@ Player movement and chat messages are totally unrelated to each other and you ab
 It would be nice if we could order player movements and chat messages separately. Guess what! This is exactly what 'arranging streams' do.
 A game developer can indicate which stream it likes to arrange the packets. 
 For example, the game developer can say: "Let me order all chat messages to 'stream 1' and sequence all motion packets on 'stream 2'.
+
+### Example
+```rust
+// We can specify on which stream and how to order our packets, checkout our book and documentation for more information
+let unreliable_sequenced = Packet::unreliable_sequenced(destination, bytes, Some(1));
+let reliable_sequenced = Packet::reliable_sequenced(destination, bytes, Some(2));
+let reliable_ordered = Packet::reliable_ordered(destination, bytes, Some(3));
+```
+
+Take notice of the last `Option` parameter, with this parameter you can specify which streams to order your packets on.
+One thing that is important to understand is that 'sequenced streams' are different from 'ordered streams', 
+thus specifying `Some(1)` for a sequence stream and `Some(1)` for an ordered stream will be arranged separately from one another.
+You can use 254 different ordering or sequencing streams, in reality you'd probably only need a few. When specifying `None`, stream '255' will be used.
 
 ## Interesting Reads
 - [RakNet Ordering Streams](http://www.raknet.net/raknet/manual/sendingpackets.html)

--- a/docs/md_book/src/reliability/reliability.md
+++ b/docs/md_book/src/reliability/reliability.md
@@ -21,35 +21,34 @@ _UDP_
 - Duplication possible.
 - No [fragmentation](./../fragmentation.md).
 
-So it would be useful if we could somehow specify the features we want on top of UDP. 
+It would be useful if we could somehow specify the features we want on top of UDP. 
 Like that you say: I want the guarantee for my packets to arrive, however they don't need to be in order. 
 Or, I don't care if my packet arrives but I do want to receive only new ones.
 
-Please check out [ordering documentation](ordering.md), it describes what ordering and sequencing is.    
+Before continuing, it would be helpful to understand the difference between ordering and sequencing: [ordering documentation](ordering.md)
 
+## The 5 Reliability Guarantees
 Laminar provides 5 different ways for you to send your data:
 
-| Reliability Type                 | Packet Drop | Packet Duplication | Packet Order  | Packet Fragmentation |Packet Delivery|
-| :-------------:                  | :-------------: | :-------------:    | :-------------:  | :-------------:  | :-------------:
-|       **Unreliable**              |       Yes       |       Yes          |      No          |      No          |       No
-|       **Unreliable Sequenced**    |       Yes       |      No            |      Sequenced   |      No          |       No
-|       **Reliable Unordered**      |       No        |      No            |      No          |      Yes         |       Yes
-|       **Reliable Ordered**        |       No        |      No            |      Ordered     |      Yes         |       Yes
-|       **Reliable Sequenced**      |       No        |      No            |      Sequenced   |      Yes         |       Yes
+| Reliability Type             | Packet Drop     | Packet Duplication | Packet Order     | Packet Fragmentation |Packet Delivery|
+| :-------------:              | :-------------: | :-------------:    | :-------------:  | :-------------:      | :-------------:
+|   **Unreliable Unordered**   |       Any       |      Yes           |     No           |      No              |   No
+|   **Unreliable Sequenced**   |    Any + old    |      No            |     Sequenced    |      No              |   No
+|   **Reliable Unordered**     |       No        |      No            |     No           |      Yes             |   Yes
+|   **Reliable Ordered**       |       No        |      No            |     Ordered      |      Yes             |   Yes
+|   **Reliable Sequenced**     |    Only old     |      No            |     Sequenced    |      Yes             |   Only newest
 
 
 ## Unreliable
-Unreliable: Packets can be dropped, duplicated or arrive without order.
+Unreliable: Packets can be dropped, duplicated or arrive in any order.
 
 **Details**
 
 | Packet Drop     | Packet Duplication | Packet Order     | Packet Fragmentation | Packet Delivery |
 | :-------------: | :-------------:    | :-------------:  | :-------------:      | :-------------: |
-|       Yes       |        Yes         |      No          |      No              |       No        |
+|       Any       |      Yes           |     No           |      No              |   No
 
 Basically just bare UDP. The packet may or may not be delivered.
-
-// todo: add use cases
 
 ## Unreliable Sequenced
 Unreliable Sequenced: Packets can be dropped, but could not be duplicated and arrive in sequence.
@@ -58,36 +57,31 @@ Unreliable Sequenced: Packets can be dropped, but could not be duplicated and ar
 
 | Packet Drop     | Packet Duplication | Packet Order     | Packet Fragmentation | Packet Delivery |
 | :-------------: | :-------------:    | :-------------:  | :-------------:      | :-------------: |
-|       Yes       |        Yes         |      Sequenced          |      No              |       No        |
+|    Any + old    |      No            |     Sequenced    |      No              |   No
 
 Basically just bare UDP, free to be dropped, but has some sequencing to it so that only the newest packets are kept.
 
-// todo: add use cases
-
 ## Reliable Unordered
-Reliable: All packets will be sent and received, but without order.
+Reliable UnOrder: All packets will be sent and received, but without order.
 
 *Details*
 
 |   Packet Drop   | Packet Duplication | Packet Order     | Packet Fragmentation | Packet Delivery |
 | :-------------: | :-------------:    | :-------------:  | :-------------:      | :-------------: |
-|       No        |      No            |      No          |      Yes             |       Yes       |
+|       No        |      No            |     No           |      Yes             |   Yes
 
 Basically, this is almost TCP without ordering of packets.
 
-// todo: add use cases
 ## Reliable Ordered
-Reliable; All packets will be sent and received, with order.
+Reliable Unordered: All packets will be sent and received, but in the order in which they arrived.
 
 *Details*
 
 |   Packet Drop   | Packet Duplication | Packet Order     | Packet Fragmentation | Packet Delivery |
 | :-------------: | :-------------:    | :-------------:  | :-------------:      | :-------------: |
-|       No        |      No            |      Ordered     |      Yes             |       Yes       |
+|       No        |      No            |     Ordered      |      Yes             |   Yes
 
 Basically this is almost like TCP.
-
-// todo: add use cases
 
 ## Reliable Sequenced
 Reliable; All packets will be sent and received but arranged in sequence.
@@ -97,11 +91,24 @@ Which means that only the newest packets will be let through, older packets will
 
 |   Packet Drop   | Packet Duplication | Packet Order     | Packet Fragmentation | Packet Delivery |
 | :-------------: | :-------------:    | :-------------:  | :-------------:      | :-------------: |
-|       No        |      No            |      Sequenced     |      Yes             |       Yes       |
+|    Only old     |      No            |     Sequenced    |      Yes             |   Only newest
 
 Basically this is almost TCP-like but then sequencing instead of ordering.
 
-// todo: add use cases
 
-## Interesting Reads
+### Example
+```rust
+use laminar::Packet;
+
+// You can create packets with different reliabilities
+let unreliable = Packet::unreliable(destination, bytes);
+let reliable = Packet::reliable_unordered(destination, bytes);
+
+// We can specify on which stream and how to order our packets, checkout our book and documentation for more information
+let unreliable = Packet::unreliable_sequenced(destination, bytes, Some(1));
+let reliable_sequenced = Packet::reliable_sequenced(destination, bytes, Some(2));
+let reliable_ordered = Packet::reliable_ordered(destination, bytes, Some(3));
+```
+
+# Related
 - [RakNet Reliability Types](http://www.jenkinssoftware.com/raknet/manual/reliabilitytypes.html)

--- a/examples/server_client.rs
+++ b/examples/server_client.rs
@@ -67,7 +67,7 @@ fn client() -> Result<(), ErrorKind> {
         socket.send(Packet::reliable_unordered(
             server,
             line.clone().into_bytes(),
-        ))?;
+        ));
 
         socket.manual_poll(Instant::now());
 

--- a/examples/udp.rs
+++ b/examples/udp.rs
@@ -20,7 +20,7 @@ fn server_address() -> SocketAddr {
 }
 
 /// This is an example of how to send data to an specific address.
-pub fn send_data() -> Result<()> {
+pub fn send_data() {
     // Setup a udp socket and bind it to the client address.
     let mut socket = Socket::bind(client_address()).unwrap();
 

--- a/src/bin/laminar-tester.rs
+++ b/src/bin/laminar-tester.rs
@@ -135,7 +135,7 @@ fn run_server(server_config: ServerConfiguration) -> Result<()> {
                     throughput.tick();
                 }
                 SocketEvent::Connect(address) => {
-                    socket.send(Packet::unreliable(address, vec![0])).unwrap();
+                    socket.send(Packet::unreliable(address, vec![0]));
                 }
                 _ => error!("Event not handled yet."),
             }
@@ -172,7 +172,7 @@ fn test_steady_stream(config: ClientConfiguration, mut socket: Socket) {
     let mut packets_sent = 0;
 
     loop {
-        socket.send(test_packet.clone()).unwrap();
+        socket.send(test_packet.clone());
         socket.manual_poll(Instant::now());
         while let Some(_) = socket.recv() {}
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -48,6 +48,12 @@ pub struct Config {
     ///
     /// Value that specifies how long we should block polling for socket events, in milliseconds. Defaults to `1ms`.
     pub socket_polling_timeout: Option<Duration>,
+    /// The maximum amount of reliable packets in flight on this connection before we drop the
+    /// connection.
+    ///
+    /// When we send a reliable packet, it is stored locally until an acknowledgement comes back to
+    /// us, if that store grows to a size
+    pub max_packets_in_flight: u16,
 }
 
 impl Default for Config {
@@ -65,6 +71,7 @@ impl Default for Config {
             rtt_max_value: 250,
             socket_event_buffer_size: 1024,
             socket_polling_timeout: Some(Duration::from_millis(1)),
+            max_packets_in_flight: 512,
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,6 +8,9 @@ pub struct Config {
     pub blocking_mode: bool,
     /// Value which can specify the amount of time that can pass without hearing from a client before considering them disconnected
     pub idle_connection_timeout: Duration,
+    /// Value which specifies at which interval (if at all) a heartbeat should be sent, if no other packet was sent in the meantime.
+    /// If None, no heartbeats will be sent (the default).
+    pub heartbeat_interval: Option<Duration>,
     /// Value which can specify the maximum size a packet can be in bytes. This value is inclusive of fragmenting; if a packet is fragmented, the total size of the fragments cannot exceed this value.
     ///
     /// Recommended value: 16384
@@ -52,6 +55,7 @@ impl Default for Config {
         Self {
             blocking_mode: false,
             idle_connection_timeout: Duration::from_secs(5),
+            heartbeat_interval: None,
             max_packet_size: (MAX_FRAGMENTS_DEFAULT * FRAGMENT_SIZE_DEFAULT) as usize,
             max_fragments: MAX_FRAGMENTS_DEFAULT as u8,
             fragment_size: FRAGMENT_SIZE_DEFAULT,

--- a/src/error.rs
+++ b/src/error.rs
@@ -125,7 +125,7 @@ pub enum FragmentErrorKind {
     /// This fragment was already processed
     AlreadyProcessedFragment,
     /// Attempted to fragment with an incorrect number of fragments
-    FragmentWithUnevenNumberOfFragemts,
+    FragmentWithUnevenNumberOfFragments,
     /// Fragment we expected to be able to find we couldn't
     CouldNotFindFragmentById,
 }
@@ -143,7 +143,7 @@ impl Display for FragmentErrorKind {
             FragmentErrorKind::AlreadyProcessedFragment => {
                 write!(fmt, "The fragment received was already processed.")
             }
-            FragmentErrorKind::FragmentWithUnevenNumberOfFragemts => write!(
+            FragmentErrorKind::FragmentWithUnevenNumberOfFragments => write!(
                 fmt,
                 "The fragment header does not contain the right fragment count."
             ),

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,5 @@
 //! This module contains the laminar error handling logic.
 
-use crate::SocketEvent;
-use crossbeam_channel::SendError;
 use std::{
     error::Error,
     fmt::{self, Display, Formatter},
@@ -26,8 +24,6 @@ pub enum ErrorKind {
     ReceivedDataToShort,
     /// Protocol versions did not match
     ProtocolVersionMismatch,
-    /// Could not send on `SendChannel`.
-    SendError(SendError<SocketEvent>),
     /// Expected header but could not be read from buffer.
     CouldNotReadHeader(String),
 }
@@ -57,11 +53,6 @@ impl Display for ErrorKind {
             ErrorKind::ProtocolVersionMismatch => {
                 write!(fmt, "The protocol versions do not match.")
             }
-            ErrorKind::SendError(e) => write!(
-                fmt,
-                "Could not sent on channel because it was closed. Reason: {:?}",
-                e
-            ),
             ErrorKind::CouldNotReadHeader(header) => write!(
                 fmt,
                 "Expected {} header but could not be read from buffer.",
@@ -182,12 +173,6 @@ impl From<PacketErrorKind> for ErrorKind {
 impl From<FragmentErrorKind> for ErrorKind {
     fn from(inner: FragmentErrorKind) -> Self {
         ErrorKind::FragmentError(inner)
-    }
-}
-
-impl From<crossbeam_channel::SendError<SocketEvent>> for ErrorKind {
-    fn from(inner: SendError<SocketEvent>) -> Self {
-        ErrorKind::SendError(inner)
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,6 +3,7 @@
 use crate::SocketEvent;
 use crossbeam_channel::SendError;
 use std::{
+    error::Error,
     fmt::{self, Display, Formatter},
     io, result,
 };
@@ -69,6 +70,8 @@ impl Display for ErrorKind {
         }
     }
 }
+
+impl Error for ErrorKind {}
 
 /// Errors that could occur while parsing packet contents
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -173,5 +176,15 @@ impl From<FragmentErrorKind> for ErrorKind {
 impl From<crossbeam_channel::SendError<SocketEvent>> for ErrorKind {
     fn from(inner: SendError<SocketEvent>) -> Self {
         ErrorKind::SendError(inner)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn able_to_box_errors() {
+        let _: Box<Error> = Box::new(ErrorKind::CouldNotReadHeader("".into()));
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -128,6 +128,10 @@ pub enum FragmentErrorKind {
     FragmentWithUnevenNumberOfFragments,
     /// Fragment we expected to be able to find we couldn't
     CouldNotFindFragmentById,
+    /// Multiple ack headers sent with these fragments
+    MultipleAckHeaders,
+    /// Ack header is missing from a finished set of fragments
+    MissingAckHeader,
 }
 
 impl Display for FragmentErrorKind {
@@ -150,6 +154,14 @@ impl Display for FragmentErrorKind {
             FragmentErrorKind::CouldNotFindFragmentById => write!(
                 fmt,
                 "The fragment supposed to be in a the cache but it was not found."
+            ),
+            FragmentErrorKind::MultipleAckHeaders => write!(
+                fmt,
+                "The fragment contains an ack header but a previous ack header has already been registered."
+            ),
+            FragmentErrorKind::MissingAckHeader => write!(
+                fmt,
+                "No ack headers were registered with any of the fragments."
             ),
         }
     }

--- a/src/infrastructure/acknowledgment.rs
+++ b/src/infrastructure/acknowledgment.rs
@@ -31,6 +31,11 @@ impl AcknowledgmentHandler {
         }
     }
 
+    /// Get the current number of not yet acknowledged packets
+    pub fn packets_in_flight(&self) -> u16 {
+        self.sent_packets.len() as u16
+    }
+
     /// Returns the next sequence number to send.
     pub fn local_sequence_num(&self) -> SequenceNumber {
         self.sequence_number

--- a/src/infrastructure/arranging/ordering.rs
+++ b/src/infrastructure/arranging/ordering.rs
@@ -347,9 +347,9 @@ mod tests {
                 stub_packet1
             );
 
-            stream.arrange(4, stub_packet4.clone()).is_none();
-            stream.arrange(5, stub_packet5.clone()).is_none();
-            stream.arrange(3, stub_packet3.clone()).is_none();
+            assert![stream.arrange(4, stub_packet4.clone()).is_none()];
+            assert![stream.arrange(5, stub_packet5.clone()).is_none()];
+            assert![stream.arrange(3, stub_packet3.clone()).is_none()];
         }
         {
             let mut iterator = stream.iter_mut();

--- a/src/infrastructure/fragmenter.rs
+++ b/src/infrastructure/fragmenter.rs
@@ -117,7 +117,7 @@ impl Fragmentation {
 
             // Got the data
             if reassembly_data.num_fragments_total != fragment_header.fragment_count() {
-                Err(FragmentErrorKind::FragmentWithUnevenNumberOfFragemts)?
+                Err(FragmentErrorKind::FragmentWithUnevenNumberOfFragments)?
             }
 
             if reassembly_data.fragments_received[usize::from(fragment_header.id())] {

--- a/src/infrastructure/fragmenter.rs
+++ b/src/infrastructure/fragmenter.rs
@@ -121,6 +121,10 @@ impl Fragmentation {
                 Err(FragmentErrorKind::FragmentWithUnevenNumberOfFragments)?
             }
 
+            if usize::from(fragment_header.id()) >= reassembly_data.fragments_received.len() {
+                Err(FragmentErrorKind::ExceededMaxFragments)?;
+            }
+
             if reassembly_data.fragments_received[usize::from(fragment_header.id())] {
                 Err(FragmentErrorKind::AlreadyProcessedFragment)?
             }

--- a/src/net/connection.rs
+++ b/src/net/connection.rs
@@ -67,6 +67,18 @@ impl ActiveConnections {
             .collect()
     }
 
+    /// Check for and return `VirtualConnection`s which have not sent anything for a duration of at least `heartbeat_interval`.
+    pub fn heartbeat_required_connections(
+        &mut self,
+        heartbeat_interval: Duration,
+        time: Instant,
+    ) -> impl Iterator<Item = &mut VirtualConnection> {
+        self.connections
+            .iter_mut()
+            .filter(move |(_, connection)| connection.last_sent(time) >= heartbeat_interval)
+            .map(|(_, connection)| connection)
+    }
+
     /// Returns true if the given connection exists.
     pub fn exists(&self, address: &SocketAddr) -> bool {
         self.connections.contains_key(&address)

--- a/src/net/connection.rs
+++ b/src/net/connection.rs
@@ -67,6 +67,15 @@ impl ActiveConnections {
             .collect()
     }
 
+    /// Get a list of addresses of dead connections
+    pub fn dead_connections(&mut self) -> Vec<SocketAddr> {
+        self.connections
+            .iter()
+            .filter(|(_, connection)| connection.should_be_dropped())
+            .map(|(address, _)| *address)
+            .collect()
+    }
+
     /// Check for and return `VirtualConnection`s which have not sent anything for a duration of at least `heartbeat_interval`.
     pub fn heartbeat_required_connections(
         &mut self,

--- a/src/net/socket.rs
+++ b/src/net/socket.rs
@@ -156,9 +156,19 @@ impl Socket {
             }
         }
 
-        // Finally check for idle clients
+        // Check for idle clients
         if let Err(e) = self.handle_idle_clients(time) {
             error!("Encountered an error when sending TimeoutEvent: {:?}", e);
+        }
+
+        // Finally send heartbeat packets to connections that require them, if enabled
+        if let Some(heartbeat_interval) = self.config.heartbeat_interval {
+            if let Err(e) = self.send_heartbeat_packets(heartbeat_interval, time) {
+                match e {
+                    ErrorKind::IOError(ref e) if e.kind() == io::ErrorKind::WouldBlock => {}
+                    _ => error!("There was an error sending a heartbeat packet: {:?}", e),
+                }
+            }
         }
     }
 
@@ -185,6 +195,35 @@ impl Socket {
         }
 
         Ok(())
+    }
+
+    /// Iterate over all connections which have not sent a packet for a duration of at least
+    /// `heartbeat_interval` (from config), and send a heartbeat packet to each.
+    fn send_heartbeat_packets(
+        &mut self,
+        heartbeat_interval: Duration,
+        time: Instant,
+    ) -> Result<usize> {
+        let heartbeat_packets_and_addrs = self
+            .connections
+            .heartbeat_required_connections(heartbeat_interval, time)
+            .map(|connection| {
+                (
+                    connection.create_and_process_heartbeat(time),
+                    connection.remote_address,
+                )
+            })
+            .collect::<Vec<_>>();
+
+        let mut bytes_sent = 0;
+
+        for (heartbeat_packet, address) in heartbeat_packets_and_addrs {
+            if self.should_send_packet() {
+                bytes_sent += self.send_packet(&address, &heartbeat_packet.contents())?;
+            }
+        }
+
+        Ok(bytes_sent)
     }
 
     // Serializes and sends a `Packet` on the socket. On success, returns the number of bytes written.
@@ -737,52 +776,111 @@ mod tests {
         let mut config = Config::default();
         config.idle_connection_timeout = Duration::from_millis(1);
 
-        let mut server = Socket::bind("127.0.0.1:12347".parse::<SocketAddr>().unwrap()).unwrap();
-        let mut client = Socket::bind("127.0.0.1:12346".parse::<SocketAddr>().unwrap()).unwrap();
+        let server_addr = "127.0.0.1:12347".parse::<SocketAddr>().unwrap();
+        let client_addr = "127.0.0.1:12346".parse::<SocketAddr>().unwrap();
+
+        let mut server = Socket::bind_with_config(server_addr, config.clone()).unwrap();
+        let mut client = Socket::bind_with_config(client_addr, config.clone()).unwrap();
 
         client
-            .send(Packet::unreliable(
-                "127.0.0.1:12347".parse().unwrap(),
-                vec![0, 1, 2],
-            ))
+            .send(Packet::unreliable(server_addr, vec![0, 1, 2]))
             .unwrap();
 
         let now = Instant::now();
         client.manual_poll(now);
         server.manual_poll(now);
 
+        assert_eq!(server.recv().unwrap(), SocketEvent::Connect(client_addr));
         assert_eq!(
             server.recv().unwrap(),
-            SocketEvent::Connect("127.0.0.1:12346".parse().unwrap())
-        );
-        assert_eq!(
-            server.recv().unwrap(),
-            SocketEvent::Packet(Packet::unreliable(
-                "127.0.0.1:12346".parse().unwrap(),
-                vec![0, 1, 2]
-            ))
+            SocketEvent::Packet(Packet::unreliable(client_addr, vec![0, 1, 2]))
         );
 
         // Acknowledge the client
         server
-            .send(Packet::unreliable(
-                "127.0.0.1:12346".parse().unwrap(),
-                vec![],
-            ))
+            .send(Packet::unreliable(client_addr, vec![]))
             .unwrap();
 
         server.manual_poll(now);
         client.manual_poll(now);
-        server.manual_poll(now + Duration::new(5, 0));
 
+        // Make sure the connection was successful on the client side
         assert_eq!(
-            server.recv().unwrap(),
-            SocketEvent::Timeout("127.0.0.1:12346".parse().unwrap())
+            client.recv().unwrap(),
+            SocketEvent::Packet(Packet::unreliable(server_addr, vec![]))
         );
+
+        // Give just enough time for no timeout events to occur (yet)
+        server.manual_poll(now + config.idle_connection_timeout - Duration::from_millis(1));
+        client.manual_poll(now + config.idle_connection_timeout - Duration::from_millis(1));
+
+        assert_eq!(server.recv(), None);
+        assert_eq!(client.recv(), None);
+
+        // Give enough time for timeouts to be detected
+        server.manual_poll(now + config.idle_connection_timeout);
+        client.manual_poll(now + config.idle_connection_timeout);
+
+        assert_eq!(server.recv().unwrap(), SocketEvent::Timeout(client_addr));
+        assert_eq!(client.recv().unwrap(), SocketEvent::Timeout(server_addr));
     }
 
-    const LOCAL_ADDR: &str = "127.0.0.1:13000";
-    const REMOTE_ADDR: &str = "127.0.0.1:14000";
+    #[test]
+    fn heartbeats_work() {
+        let mut config = Config::default();
+        config.idle_connection_timeout = Duration::from_millis(10);
+        config.heartbeat_interval = Some(Duration::from_millis(4));
+
+        let server_addr = "127.0.0.1:12351".parse::<SocketAddr>().unwrap();
+        let client_addr = "127.0.0.1:12352".parse::<SocketAddr>().unwrap();
+
+        // Start up a server and a client.
+        let mut server = Socket::bind_with_config(server_addr, config.clone()).unwrap();
+        let mut client = Socket::bind_with_config(client_addr, config.clone()).unwrap();
+
+        // Initiate a connection
+        client
+            .send(Packet::unreliable(server_addr, vec![0, 1, 2]))
+            .unwrap();
+
+        let now = Instant::now();
+        client.manual_poll(now);
+        server.manual_poll(now);
+
+        // Make sure the connection was successful on the server side
+        assert_eq!(server.recv().unwrap(), SocketEvent::Connect(client_addr));
+        assert_eq!(
+            server.recv().unwrap(),
+            SocketEvent::Packet(Packet::unreliable(client_addr, vec![0, 1, 2]))
+        );
+
+        // Acknowledge the client
+        // This way, the server also knows about the connection and sends heartbeats
+        server
+            .send(Packet::unreliable(client_addr, vec![]))
+            .unwrap();
+
+        server.manual_poll(now);
+        client.manual_poll(now);
+
+        // Make sure the connection was successful on the client side
+        assert_eq!(
+            client.recv().unwrap(),
+            SocketEvent::Packet(Packet::unreliable(server_addr, vec![]))
+        );
+
+        // Give time to send heartbeats
+        client.manual_poll(now + config.heartbeat_interval.unwrap());
+        server.manual_poll(now + config.heartbeat_interval.unwrap());
+
+        // Give time for timeouts to occur if no heartbeats were sent
+        client.manual_poll(now + config.idle_connection_timeout);
+        server.manual_poll(now + config.idle_connection_timeout);
+
+        // Assert that no disconnection events occurred
+        assert_eq!(client.recv(), None);
+        assert_eq!(server.recv(), None);
+    }
 
     fn create_test_packet(id: u8, addr: &str) -> Packet {
         let payload = vec![id];
@@ -801,6 +899,9 @@ mod tests {
 
     #[test]
     fn multiple_sends_should_start_sending_dropped() {
+        const LOCAL_ADDR: &str = "127.0.0.1:13000";
+        const REMOTE_ADDR: &str = "127.0.0.1:14000";
+
         // Start up a server and a client.
         let mut server = Socket::bind(REMOTE_ADDR.parse::<SocketAddr>().unwrap()).unwrap();
         let mut client = Socket::bind(LOCAL_ADDR.parse::<SocketAddr>().unwrap()).unwrap();

--- a/src/net/socket.rs
+++ b/src/net/socket.rs
@@ -618,11 +618,14 @@ mod tests {
 
     #[test]
     fn do_not_duplicate_sequenced_packets_when_received() {
-        let server_addr = "127.0.0.1:12325".parse::<SocketAddr>().unwrap();
-        let client_addr = "127.0.0.1:12326".parse::<SocketAddr>().unwrap();
+        let mut config = Config::default();
 
-        let mut server = Socket::bind(server_addr).unwrap();
-        let mut client = Socket::bind(client_addr).unwrap();
+        let mut client = Socket::bind_any_with_config(config.clone()).unwrap();
+        config.blocking_mode = true;
+        let mut server = Socket::bind_any_with_config(config).unwrap();
+
+        let server_addr = server.local_addr().unwrap();
+        let client_addr = client.local_addr().unwrap();
 
         let time = Instant::now();
 
@@ -631,9 +634,8 @@ mod tests {
                 .send(Packet::reliable_sequenced(server_addr, vec![id], None))
                 .unwrap();
             client.manual_poll(time);
+            server.manual_poll(time);
         }
-
-        server.manual_poll(time);
 
         let mut seen = HashSet::new();
 
@@ -652,6 +654,51 @@ mod tests {
         }
 
         assert_eq![100, seen.len()];
+    }
+
+    #[test]
+    fn more_than_65536_sequenced_packets() {
+        let mut config = Config::default();
+
+        let mut client = Socket::bind_any_with_config(config.clone()).unwrap();
+        config.blocking_mode = true;
+        let mut server = Socket::bind_any_with_config(config).unwrap();
+
+        let server_addr = server.local_addr().unwrap();
+        let client_addr = client.local_addr().unwrap();
+
+        // Acknowledge the client
+        server
+            .send(Packet::unreliable(client_addr, vec![0]))
+            .unwrap();
+
+        let time = Instant::now();
+
+        for id in 0..65536 + 100 {
+            client
+                .send(Packet::unreliable_sequenced(
+                    server_addr,
+                    id.to_string().as_bytes().to_vec(),
+                    None,
+                ))
+                .unwrap();
+            client.manual_poll(time);
+            server.manual_poll(time);
+        }
+
+        let mut cnt = 0;
+        while let Some(message) = server.recv() {
+            match message {
+                SocketEvent::Connect(_) => {}
+                SocketEvent::Packet(packet) => {
+                    cnt += 1;
+                }
+                SocketEvent::Timeout(_) => {
+                    panic!["This should not happen, as we've not advanced time"];
+                }
+            }
+        }
+        assert_eq![65536 + 100, cnt];
     }
 
     #[test]

--- a/src/net/socket.rs
+++ b/src/net/socket.rs
@@ -1207,4 +1207,81 @@ mod tests {
 
         assert_eq!["99999", last_payload];
     }
+
+    #[test]
+    fn fragmented_ordered_gets_acked() {
+        let mut cfg = Config::default();
+        cfg.fragment_size = 10;
+
+        let mut client = Socket::bind_any_with_config(cfg.clone()).unwrap();
+        let client_addr = client.local_addr().unwrap();
+
+        cfg.blocking_mode = true;
+        let mut server = Socket::bind_any_with_config(cfg).unwrap();
+        let server_addr = server.local_addr().unwrap();
+
+        let time = Instant::now();
+        let dummy = vec![0];
+
+        // ---
+
+        client
+            .send(Packet::unreliable(server_addr, dummy.clone()))
+            .unwrap();
+        client.manual_poll(time);
+        server
+            .send(Packet::unreliable(client_addr, dummy.clone()))
+            .unwrap();
+        server.manual_poll(time);
+
+        // ---
+
+        let exceeds = b"Fragmented string".to_vec();
+        client
+            .send(Packet::reliable_ordered(server_addr, exceeds, None))
+            .unwrap();
+        client.manual_poll(time);
+
+        server.manual_poll(time);
+        server.manual_poll(time);
+        server
+            .send(Packet::reliable_ordered(client_addr, dummy.clone(), None))
+            .unwrap();
+
+        client
+            .send(Packet::unreliable(server_addr, dummy.clone()))
+            .unwrap();
+        client.manual_poll(time);
+        server.manual_poll(time);
+
+        for _ in 0..4 {
+            assert![server.recv().is_some()];
+        }
+        assert![server.recv().is_none()];
+
+        for _ in 0..34 {
+            client
+                .send(Packet::reliable_ordered(server_addr, dummy.clone(), None))
+                .unwrap();
+            client.manual_poll(time);
+            server
+                .send(Packet::reliable_ordered(client_addr, dummy.clone(), None))
+                .unwrap();
+            server.manual_poll(time);
+            assert![client.recv().is_some()];
+            // If the last iteration returns None here, it indicates we just received a re-sent
+            // fragment, because `manual_poll` only processes a single incoming UDP packet per
+            // `manual_poll` if and only if the socket is in blocking mode.
+            //
+            // If that functionality is changed, we will receive something unexpected here
+            match server.recv() {
+                Some(SocketEvent::Packet(pkt)) => {
+                    assert_eq![dummy, pkt.payload()];
+                }
+                _ => {
+                    panic!["Did not receive expected dummy packet"];
+                }
+            }
+        }
+    }
 }

--- a/src/net/socket.rs
+++ b/src/net/socket.rs
@@ -359,6 +359,7 @@ impl Socket {
     #[cfg(test)]
     fn forget_all_incoming_packets(&mut self) {
         std::thread::sleep(std::time::Duration::from_millis(100));
+        self.socket.set_nonblocking(true);
         loop {
             match self.socket.recv_from(&mut self.recv_buffer) {
                 Ok((recv_len, _address)) => {
@@ -371,11 +372,13 @@ impl Socket {
                     if e.kind() != io::ErrorKind::WouldBlock {
                         panic!("Encountered an error receiving data: {:?}", e);
                     } else {
+                        self.socket.set_nonblocking(!self.config.blocking_mode);
                         return;
                     }
                 }
             }
         }
+        self.socket.set_nonblocking(!self.config.blocking_mode);
     }
 }
 

--- a/src/net/virtual_connection.rs
+++ b/src/net/virtual_connection.rs
@@ -139,17 +139,16 @@ impl VirtualConnection {
                         );
 
                         if let OrderingGuarantee::Ordered(stream_id) = ordering_guarantee {
-                            let item_identifier = if let Some(item_identifier) =
-                                last_item_identifier
-                            {
-                                item_identifier
-                            } else {
-                                self.ordering_system
-                                    .get_or_create_stream(
-                                        stream_id.unwrap_or(DEFAULT_ORDERING_STREAM),
-                                    )
-                                    .new_item_identifier() as u16
-                            };
+                            let item_identifier =
+                                if let Some(item_identifier) = last_item_identifier {
+                                    item_identifier
+                                } else {
+                                    self.ordering_system
+                                        .get_or_create_stream(
+                                            stream_id.unwrap_or(DEFAULT_ORDERING_STREAM),
+                                        )
+                                        .new_item_identifier()
+                                };
 
                             item_identifier_value = Some(item_identifier);
 
@@ -157,17 +156,16 @@ impl VirtualConnection {
                         };
 
                         if let OrderingGuarantee::Sequenced(stream_id) = ordering_guarantee {
-                            let item_identifier = if let Some(item_identifier) =
-                                last_item_identifier
-                            {
-                                item_identifier
-                            } else {
-                                self.sequencing_system
-                                    .get_or_create_stream(
-                                        stream_id.unwrap_or(DEFAULT_SEQUENCING_STREAM),
-                                    )
-                                    .new_item_identifier() as u16
-                            };
+                            let item_identifier =
+                                if let Some(item_identifier) = last_item_identifier {
+                                    item_identifier
+                                } else {
+                                    self.sequencing_system
+                                        .get_or_create_stream(
+                                            stream_id.unwrap_or(DEFAULT_SEQUENCING_STREAM),
+                                        )
+                                        .new_item_identifier()
+                                };
 
                             item_identifier_value = Some(item_identifier);
 

--- a/src/net/virtual_connection.rs
+++ b/src/net/virtual_connection.rs
@@ -293,11 +293,12 @@ impl VirtualConnection {
                     if let Ok((fragment_header, acked_header)) = packet_reader.read_fragment() {
                         let payload = packet_reader.read_payload();
 
-                        match self
-                            .fragmentation
-                            .handle_fragment(fragment_header, &payload)
-                        {
-                            Ok(Some(payload)) => {
+                        match self.fragmentation.handle_fragment(
+                            fragment_header,
+                            &payload,
+                            acked_header,
+                        ) {
+                            Ok(Some((payload, acked_header))) => {
                                 Self::queue_packet(
                                     sender,
                                     payload.into_boxed_slice(),
@@ -305,20 +306,18 @@ impl VirtualConnection {
                                     header.delivery_guarantee(),
                                     OrderingGuarantee::None,
                                 )?;
+
+                                self.congestion_handler
+                                    .process_incoming(acked_header.sequence());
+                                self.acknowledge_handler.process_incoming(
+                                    acked_header.sequence(),
+                                    acked_header.ack_seq(),
+                                    acked_header.ack_field(),
+                                );
                             }
                             Ok(None) => return Ok(()),
                             Err(e) => return Err(e),
                         };
-
-                        if let Some(acked_header) = acked_header {
-                            self.congestion_handler
-                                .process_incoming(acked_header.sequence());
-                            self.acknowledge_handler.process_incoming(
-                                acked_header.sequence(),
-                                acked_header.ack_seq(),
-                                acked_header.ack_field(),
-                            );
-                        }
                     }
                 } else {
                     let acked_header = packet_reader.read_acknowledge_header()?;
@@ -463,10 +462,10 @@ mod tests {
 
         let standard_header = [protocol_version, vec![1, 1, 2]].concat();
 
-        let acked_header = vec![1, 0, 0, 2, 0, 0, 0, 3];
-        let first_fragment = vec![0, 1, 1, 3];
-        let second_fragment = vec![0, 1, 2, 3];
-        let third_fragment = vec![0, 1, 3, 3];
+        let acked_header = vec![0, 0, 0, 4, 0, 0, 255, 255, 0, 0, 0, 0];
+        let first_fragment = vec![0, 0, 1, 4];
+        let second_fragment = vec![0, 0, 2, 4];
+        let third_fragment = vec![0, 0, 3, 4];
 
         let (tx, rx) = unbounded::<SocketEvent>();
 

--- a/src/net/virtual_connection.rs
+++ b/src/net/virtual_connection.rs
@@ -56,6 +56,11 @@ impl VirtualConnection {
         }
     }
 
+    /// Determine if this connection should be dropped due to its state
+    pub fn should_be_dropped(&self) -> bool {
+        self.acknowledge_handler.packets_in_flight() > self.config.max_packets_in_flight
+    }
+
     /// Returns a [Duration] representing the interval since we last heard from the client
     pub fn last_heard(&self, time: Instant) -> Duration {
         // TODO: Replace with saturating_duration_since once it becomes stable.

--- a/src/net/virtual_connection.rs
+++ b/src/net/virtual_connection.rs
@@ -274,7 +274,7 @@ impl VirtualConnection {
                             self.remote_address,
                             header.delivery_guarantee(),
                             OrderingGuarantee::Sequenced(Some(arranging_header.stream_id())),
-                        )?;
+                        );
                     }
 
                     return Ok(());
@@ -286,7 +286,7 @@ impl VirtualConnection {
                     self.remote_address,
                     header.delivery_guarantee(),
                     header.ordering_guarantee(),
-                )?;
+                );
             }
             DeliveryGuarantee::Reliable => {
                 if header.is_fragment() {
@@ -305,7 +305,7 @@ impl VirtualConnection {
                                     self.remote_address,
                                     header.delivery_guarantee(),
                                     header.ordering_guarantee(),
-                                )?;
+                                );
 
                                 self.congestion_handler
                                     .process_incoming(acked_header.sequence());
@@ -342,7 +342,7 @@ impl VirtualConnection {
                                 self.remote_address,
                                 header.delivery_guarantee(),
                                 OrderingGuarantee::Sequenced(Some(arranging_header.stream_id())),
-                            )?;
+                            );
                         }
                     } else if let OrderingGuarantee::Ordered(_id) = header.ordering_guarantee() {
                         let arranging_header = packet_reader.read_arranging_header(u16::from(
@@ -364,7 +364,7 @@ impl VirtualConnection {
                                 self.remote_address,
                                 header.delivery_guarantee(),
                                 OrderingGuarantee::Ordered(Some(arranging_header.stream_id())),
-                            )?;
+                            );
 
                             while let Some(packet) = stream.iter_mut().next() {
                                 Self::queue_packet(
@@ -373,7 +373,7 @@ impl VirtualConnection {
                                     self.remote_address,
                                     header.delivery_guarantee(),
                                     OrderingGuarantee::Ordered(Some(arranging_header.stream_id())),
-                                )?;
+                                );
                             }
                         }
                     } else {
@@ -385,7 +385,7 @@ impl VirtualConnection {
                             self.remote_address,
                             header.delivery_guarantee(),
                             header.ordering_guarantee(),
-                        )?;
+                        );
                     }
 
                     self.congestion_handler
@@ -408,14 +408,14 @@ impl VirtualConnection {
         remote_addr: SocketAddr,
         delivery: DeliveryGuarantee,
         ordering: OrderingGuarantee,
-    ) -> Result<()> {
+    ) {
         tx.send(SocketEvent::Packet(Packet::new(
             remote_addr,
             payload,
             delivery,
             ordering,
-        )))?;
-        Ok(())
+        )))
+        .unwrap();
     }
 
     /// This will gather dropped packets from the acknowledgment handler.

--- a/src/net/virtual_connection.rs
+++ b/src/net/virtual_connection.rs
@@ -304,7 +304,7 @@ impl VirtualConnection {
                                     payload.into_boxed_slice(),
                                     self.remote_address,
                                     header.delivery_guarantee(),
-                                    OrderingGuarantee::None,
+                                    header.ordering_guarantee(),
                                 )?;
 
                                 self.congestion_handler

--- a/src/packet/enums.rs
+++ b/src/packet/enums.rs
@@ -88,6 +88,8 @@ pub enum PacketType {
     Packet = 0,
     /// Fragment of a full packet
     Fragment = 1,
+    /// Heartbeat packet
+    Heartbeat = 2,
 }
 
 impl EnumConverter for PacketType {
@@ -104,6 +106,7 @@ impl TryFrom<u8> for PacketType {
         match value {
             0 => Ok(PacketType::Packet),
             1 => Ok(PacketType::Fragment),
+            2 => Ok(PacketType::Heartbeat),
             _ => Err(ErrorKind::DecodingError(DecodingErrorKind::PacketType)),
         }
     }
@@ -152,9 +155,10 @@ mod tests {
     }
 
     #[test]
-    fn assure_parsing_packet_id() {
+    fn assure_parsing_packet_type() {
         let packet = PacketType::Packet;
         let fragment = PacketType::Fragment;
+        let heartbeat = PacketType::Heartbeat;
         assert_eq!(
             PacketType::Packet,
             PacketType::try_from(packet.to_u8()).unwrap()
@@ -162,6 +166,10 @@ mod tests {
         assert_eq!(
             PacketType::Fragment,
             PacketType::try_from(fragment.to_u8()).unwrap()
+        );
+        assert_eq!(
+            PacketType::Heartbeat,
+            PacketType::try_from(heartbeat.to_u8()).unwrap()
         );
     }
 }

--- a/src/packet/header/acked_packet_header.rs
+++ b/src/packet/header/acked_packet_header.rs
@@ -85,7 +85,7 @@ mod tests {
     fn serialize() {
         let mut buffer = Vec::new();
         let header = AckedPacketHeader::new(1, 2, 3);
-        header.parse(&mut buffer).is_ok();
+        assert![header.parse(&mut buffer).is_ok()];
 
         assert_eq!(buffer[1], 1);
         assert_eq!(buffer[3], 2);

--- a/src/packet/header/arranging_header.rs
+++ b/src/packet/header/arranging_header.rs
@@ -74,7 +74,7 @@ mod tests {
     fn serialize() {
         let mut buffer = Vec::new();
         let header = ArrangingHeader::new(1, 2);
-        header.parse(&mut buffer).is_ok();
+        assert![header.parse(&mut buffer).is_ok()];
 
         assert_eq!(buffer[1], 1);
         assert_eq!(buffer[2], 2);

--- a/src/packet/header/fragment_header.rs
+++ b/src/packet/header/fragment_header.rs
@@ -83,7 +83,7 @@ mod tests {
     fn serialize() {
         let mut buffer = Vec::new();
         let header = FragmentHeader::new(1, 2, 3);
-        header.parse(&mut buffer).is_ok();
+        assert![header.parse(&mut buffer).is_ok()];
 
         assert_eq!(buffer[1], 1);
         assert_eq!(buffer[2], 2);

--- a/src/packet/header/standard_header.rs
+++ b/src/packet/header/standard_header.rs
@@ -126,7 +126,7 @@ mod tests {
             OrderingGuarantee::Sequenced(None),
             PacketType::Packet,
         );
-        header.parse(&mut buffer).is_ok();
+        assert![header.parse(&mut buffer).is_ok()];
 
         // [0 .. 3] protocol version
         assert_eq!(buffer[2], PacketType::Packet.to_u8());

--- a/src/packet/header/standard_header.rs
+++ b/src/packet/header/standard_header.rs
@@ -17,7 +17,7 @@ pub struct StandardHeader {
 }
 
 impl StandardHeader {
-    /// Create new heartbeat header.
+    /// Create new header.
     pub fn new(
         delivery_guarantee: DeliveryGuarantee,
         ordering_guarantee: OrderingGuarantee,
@@ -51,6 +51,11 @@ impl StandardHeader {
     #[cfg(test)]
     pub fn packet_type(&self) -> PacketType {
         self.packet_type
+    }
+
+    /// Returns true if the packet is a heartbeat packet, false otherwise
+    pub fn is_heartbeat(&self) -> bool {
+        self.packet_type == PacketType::Heartbeat
     }
 
     /// Returns true if the packet is a fragment, false if not

--- a/src/packet/packet_structure.rs
+++ b/src/packet/packet_structure.rs
@@ -5,14 +5,15 @@ use std::net::SocketAddr;
 /// This is a user friendly packet containing the payload, endpoint, and reliability guarantees.
 /// A packet could have reliability guarantees to specify how it should be delivered and processed.
 ///
-/// | Reliability Type                 | Packet Drop | Packet Duplication | Packet Order  | Packet Fragmentation |Packet Delivery|
-/// | :-------------:                  | :-------------: | :-------------:    | :-------------:  | :-------------:    | :-------------:
-/// |       **Unreliable Unordered**   |       Yes       |       Yes          |      No          |      No             |       No
-/// |       **Reliable Unordered**     |       No        |      No            |      No          |      Yes             |       Yes
-/// |       **Reliable Ordered**       |       No        |      No            |      Ordered |      Yes             |       Yes
-/// |       **Sequenced**              |       Yes       |      No            |      Sequenced |      No |       No
+/// | Reliability Type             | Packet Drop     | Packet Duplication | Packet Order     | Packet Fragmentation |Packet Delivery|
+/// | :-------------:              | :-------------: | :-------------:    | :-------------:  | :-------------:      | :-------------:
+/// |   **Unreliable Unordered**   |       Any       |      Yes           |     No           |      No              |   No
+/// |   **Unreliable Sequenced**   |    Any + old    |      No            |     Sequenced    |      No              |   No
+/// |   **Reliable Unordered**     |       No        |      No            |     No           |      Yes             |   Yes
+/// |   **Reliable Ordered**       |       No        |      No            |     Ordered      |      Yes             |   Yes
+/// |   **Reliable Sequenced**     |    Only old     |      No            |     Sequenced    |      Yes             |   Only newest
 ///
-/// You are able to send packets with any the above guarantees.
+/// You are able to send packets with the above reliability types.
 pub struct Packet {
     /// the endpoint from where it came
     addr: SocketAddr,
@@ -48,7 +49,7 @@ impl Packet {
     ///
     /// | Packet Drop     | Packet Duplication | Packet Order     | Packet Fragmentation | Packet Delivery |
     /// | :-------------: | :-------------:    | :-------------:  | :-------------:      | :-------------: |
-    /// |       Yes       |        Yes         |      No          |      No              |       No        |
+    /// |       Any       |        Yes         |      No          |      No              |       No        |
     ///
     /// Basically just bare UDP. The packet may or may not be delivered.
     pub fn unreliable(addr: SocketAddr, payload: Vec<u8>) -> Packet {
@@ -68,7 +69,7 @@ impl Packet {
     ///
     /// | Packet Drop     | Packet Duplication | Packet Order     | Packet Fragmentation | Packet Delivery |
     /// | :-------------: | :-------------:    | :-------------:  | :-------------:      | :-------------: |
-    /// |       Yes       |        Yes         |      Sequenced          |      No              |       No        |
+    /// |    Any + old    |        No          |      Sequenced   |      No              |       No        |
     ///
     /// Basically just bare UDP, free to be dropped, but has some sequencing to it so that only the newest packets are kept.
     pub fn unreliable_sequenced(
@@ -135,7 +136,7 @@ impl Packet {
     ///
     /// |   Packet Drop   | Packet Duplication | Packet Order     | Packet Fragmentation | Packet Delivery |
     /// | :-------------: | :-------------:    | :-------------:  | :-------------:      | :-------------: |
-    /// |       Yes        |      No            |      Sequenced     |      Yes             |       Yes       |
+    /// |    Only old     |      No            |      Sequenced   |      Yes             |   Only newest   |
     ///
     /// Basically this is almost TCP-like but then sequencing instead of ordering.
     ///

--- a/src/sequence_buffer.rs
+++ b/src/sequence_buffer.rs
@@ -69,12 +69,14 @@ impl<T: Clone + Default> SequenceBuffer<T> {
     }
 
     /// Removes an entry from the sequence buffer
-    pub fn remove(&mut self, sequence_num: SequenceNumber) {
+    pub fn remove(&mut self, sequence_num: SequenceNumber) -> Option<T> {
         if self.exists(sequence_num) {
             let index = self.index(sequence_num);
-            self.entries[index] = T::default();
+            let value = std::mem::replace(&mut self.entries[index], T::default());
             self.entry_sequences[index] = None;
+            return Some(value);
         }
+        None
     }
 
     // Advances the sequence number while removing older entries.

--- a/src/sequence_buffer/reassembly_data.rs
+++ b/src/sequence_buffer/reassembly_data.rs
@@ -1,4 +1,5 @@
 use crate::net::constants::MAX_FRAGMENTS_DEFAULT;
+use crate::packet::header::AckedPacketHeader;
 use crate::packet::SequenceNumber;
 
 #[derive(Clone)]
@@ -9,6 +10,7 @@ pub struct ReassemblyData {
     pub num_fragments_total: u8,
     pub buffer: Vec<u8>,
     pub fragments_received: [bool; MAX_FRAGMENTS_DEFAULT as usize],
+    pub acked_header: Option<AckedPacketHeader>,
 }
 
 impl ReassemblyData {
@@ -19,6 +21,7 @@ impl ReassemblyData {
             num_fragments_total,
             buffer: Vec::with_capacity(prealloc),
             fragments_received: [false; MAX_FRAGMENTS_DEFAULT as usize],
+            acked_header: None,
         }
     }
 }
@@ -31,6 +34,7 @@ impl Default for ReassemblyData {
             num_fragments_total: 0,
             buffer: Vec::with_capacity(1024),
             fragments_received: [false; MAX_FRAGMENTS_DEFAULT as usize],
+            acked_header: None,
         }
     }
 }


### PR DESCRIPTION
Simple as that.
[`SendError`](https://docs.rs/crossbeam-channel/0.1.2/crossbeam_channel/struct.SendError.html) can never happen within laminar, because of crossbeam's `Sender` and `Receiver` always exists together.
> ... can **only** fail if the receiving end of a channel is disconnected ...

Breaking changes in API:
* Changed "pub fn send(&mut self, packet: Packet)~~->Result<()>~~" in `Socket`.
* Removed `SendError` from `ErrorKind`.
