### PR TITLE
Iterable VirtualConnection process_* functions result.

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -103,6 +103,8 @@ impl Display for DecodingErrorKind {
 pub enum PacketErrorKind {
     /// The maximal allowed size of the packet was exceeded
     ExceededMaxPacketSize,
+    /// Only `PacketType::Packet` can be fragmented
+    PacketCannotBeFragmented,
 }
 
 impl Display for PacketErrorKind {
@@ -110,6 +112,9 @@ impl Display for PacketErrorKind {
         match *self {
             PacketErrorKind::ExceededMaxPacketSize => {
                 write!(fmt, "The packet size was bigger than the max allowed size.")
+            }
+            PacketErrorKind::PacketCannotBeFragmented => {
+                write!(fmt, "The packet type cannot be fragmented.")
             }
         }
     }

--- a/src/net/socket.rs
+++ b/src/net/socket.rs
@@ -22,12 +22,14 @@ struct SocketWithConditioner {
 }
 
 impl SocketWithConditioner {
+    /// Creates an instance of `SocketWithConditioner`
     pub fn new(socket: UdpSocket, link_conditioner: Option<LinkConditioner>) -> Self {
         Self {
             socket,
             link_conditioner,
         }
     }
+
     // In the presence of a link conditioner, we would like it to determine whether or not we should
     // send a single packet over the UDP socket.
     pub fn send_packet(&mut self, addr: &SocketAddr, payload: &[u8]) -> Result<usize> {
@@ -39,14 +41,17 @@ impl SocketWithConditioner {
         Ok(self.socket.send_to(payload, addr)?)
     }
 
+    /// Returns mutable reference of `UdpSocket`
     pub fn socket(&mut self) -> &mut UdpSocket {
         &mut self.socket
     }
 
+    /// Returns the local socket address
     pub fn local_addr(&self) -> Result<SocketAddr> {
         Ok(self.socket.local_addr()?)
     }
 
+    /// Set the link conditioner for this socket. See [LinkConditioner] for further details.
     pub fn set_link_conditioner(&mut self, conditioner: Option<LinkConditioner>) {
         self.link_conditioner = conditioner;
     }
@@ -216,7 +221,7 @@ impl Socket {
         self.socket_wrapper.set_link_conditioner(link_conditioner);
     }
 
-    /// Get the local socket address
+    /// Returns the local socket address
     pub fn local_addr(&self) -> Result<SocketAddr> {
         self.socket_wrapper.local_addr()
     }
@@ -354,9 +359,9 @@ impl Socket {
                     Left(existing) => existing.process_incoming(received_payload, time)?,
                     Right(mut anonymous) => anonymous.process_incoming(received_payload, time)?,
                 };
-                for (incoming, _) in packets {
+                for incoming in packets {
                     self.event_sender
-                        .send(SocketEvent::Packet(incoming))
+                        .send(SocketEvent::Packet(incoming.0))
                         .unwrap();
                 }
             }

--- a/src/net/virtual_connection.rs
+++ b/src/net/virtual_connection.rs
@@ -21,8 +21,8 @@ use std::net::SocketAddr;
 use std::time::{Duration, Instant};
 
 use std::collections::VecDeque;
-/// Helper class that implement Iterator, and is used to return incomming (from bytes to packets) or outgoing (from packet to bytes) packets.
-/// It is used as optimization in cases, where most of the time there is only one element to iterate, and we don't want to create vector for it
+/// Helper class that implements `Iterator`, and is used to return incoming (from bytes to packets) or outgoing (from packet to bytes) packets.
+/// It is used as optimization in cases, where most of the time there is only one element to iterate, and we don't want to create a vector for it
 pub struct ZeroOrMore<T> {
     data: Either<Option<T>, VecDeque<T>>,
 }
@@ -58,7 +58,7 @@ impl<T> Iterator for ZeroOrMore<T> {
     }
 }
 
-/// Stores packets with headers that will be sent to network
+/// Stores packets with headers that will be sent to the network
 pub struct OutgoingPackets<'a> {
     data: ZeroOrMore<OutgoingPacket<'a>>,
 }

--- a/src/net/virtual_connection.rs
+++ b/src/net/virtual_connection.rs
@@ -1,5 +1,6 @@
 use crate::{
     config::Config,
+    either::Either,
     error::{ErrorKind, PacketErrorKind, Result},
     infrastructure::{
         arranging::{Arranging, ArrangingSystem, OrderingSystem, SequencingSystem},
@@ -10,16 +11,113 @@ use crate::{
         STANDARD_HEADER_SIZE,
     },
     packet::{
-        DeliveryGuarantee, OrderingGuarantee, Outgoing, OutgoingPacket, OutgoingPacketBuilder,
+        DeliveryGuarantee, GenericPacket, OrderingGuarantee, OutgoingPacket, OutgoingPacketBuilder,
         Packet, PacketReader, PacketType, SequenceNumber,
     },
-    SocketEvent,
 };
 
-use crossbeam_channel::{self, Sender};
 use std::fmt;
 use std::net::SocketAddr;
 use std::time::{Duration, Instant};
+
+use std::collections::VecDeque;
+/// Helper class that implement Iterator, and is used to return incomming (from bytes to packets) or outgoing (from packet to bytes) packets.
+/// It is used as optimization in cases, where most of the time there is only one element to iterate, and we don't want to create vector for it
+pub struct ZeroOrMore<T> {
+    data: Either<Option<T>, VecDeque<T>>,
+}
+
+impl<T> ZeroOrMore<T> {
+    fn zero() -> Self {
+        Self {
+            data: Either::Left(None),
+        }
+    }
+
+    fn one(data: T) -> Self {
+        Self {
+            data: Either::Left(Some(data)),
+        }
+    }
+
+    fn many(vec: VecDeque<T>) -> Self {
+        Self {
+            data: Either::Right(vec),
+        }
+    }
+}
+
+impl<T> Iterator for ZeroOrMore<T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match &mut self.data {
+            Either::Left(option) => option.take(),
+            Either::Right(vec) => vec.pop_front(),
+        }
+    }
+}
+
+/// Stores packets with headers that will be sent to network
+pub struct OutgoingPackets<'a> {
+    data: ZeroOrMore<OutgoingPacket<'a>>,
+}
+
+impl<'a> OutgoingPackets<'a> {
+    fn one(packet: OutgoingPacket<'a>) -> Self {
+        Self {
+            data: ZeroOrMore::one(packet),
+        }
+    }
+    fn many(packets: VecDeque<OutgoingPacket<'a>>) -> Self {
+        Self {
+            data: ZeroOrMore::many(packets),
+        }
+    }
+}
+
+impl<'a> IntoIterator for OutgoingPackets<'a> {
+    type Item = OutgoingPacket<'a>;
+    type IntoIter = ZeroOrMore<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.data
+    }
+}
+
+/// Stores parsed packets with their types, that was received from network
+pub struct IncomingPackets {
+    data: ZeroOrMore<(Packet, PacketType)>,
+}
+
+impl IncomingPackets {
+    fn zero() -> Self {
+        Self {
+            data: ZeroOrMore::zero(),
+        }
+    }
+
+    fn one(packet: Packet, packet_type: PacketType) -> Self {
+        Self {
+            data: ZeroOrMore::one((packet, packet_type)),
+        }
+    }
+
+    fn many(vec: VecDeque<(Packet, PacketType)>) -> Self {
+        Self {
+            data: ZeroOrMore::many(vec),
+        }
+    }
+}
+
+impl IntoIterator for IncomingPackets {
+    type Item = (Packet, PacketType);
+    type IntoIter = ZeroOrMore<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.data
+    }
+}
 
 /// Contains the information about a certain 'virtual connection' over udp.
 /// This connections also keeps track of network quality, processing packets, buffering data related to connection etc.
@@ -31,7 +129,7 @@ pub struct VirtualConnection {
     /// The address of the remote endpoint
     pub remote_address: SocketAddr,
 
-    ordering_system: OrderingSystem<Box<[u8]>>,
+    ordering_system: OrderingSystem<(Box<[u8]>, PacketType)>,
     sequencing_system: SequencingSystem<Box<[u8]>>,
     acknowledge_handler: AcknowledgmentHandler,
     congestion_handler: CongestionHandler,
@@ -75,40 +173,27 @@ impl VirtualConnection {
         time.duration_since(self.last_sent)
     }
 
-    /// This will create a heartbeat packet that is expected to be sent over the network
-    pub fn create_and_process_heartbeat(&mut self, time: Instant) -> OutgoingPacket<'static> {
-        self.last_sent = time;
-        self.congestion_handler
-            .process_outgoing(self.acknowledge_handler.local_sequence_num(), time);
-
-        OutgoingPacketBuilder::new(&[])
-            .with_default_header(
-                PacketType::Heartbeat,
-                DeliveryGuarantee::Unreliable,
-                OrderingGuarantee::None,
-            )
-            .build()
-    }
-
     /// This will pre-process the given buffer to be sent over the network.
     pub fn process_outgoing<'a>(
         &mut self,
-        payload: &'a [u8],
-        delivery_guarantee: DeliveryGuarantee,
-        ordering_guarantee: OrderingGuarantee,
+        packet: GenericPacket<'a>,
         last_item_identifier: Option<SequenceNumber>,
         time: Instant,
-    ) -> Result<Outgoing<'a>> {
-        match delivery_guarantee {
+    ) -> Result<OutgoingPackets<'a>> {
+        self.last_sent = time;
+        match packet.delivery {
             DeliveryGuarantee::Unreliable => {
-                if payload.len() <= self.config.receive_buffer_max_size {
-                    let mut builder = OutgoingPacketBuilder::new(payload).with_default_header(
-                        PacketType::Packet,
-                        delivery_guarantee,
-                        ordering_guarantee,
-                    );
+                if packet.payload.len() <= self.config.receive_buffer_max_size {
+                    if packet.packet_type == PacketType::Heartbeat {
+                        // TODO (bug?) is this really required here?
+                        self.congestion_handler
+                            .process_outgoing(self.acknowledge_handler.local_sequence_num(), time);
+                    }
 
-                    if let OrderingGuarantee::Sequenced(stream_id) = ordering_guarantee {
+                    let mut builder = OutgoingPacketBuilder::new(packet.payload)
+                        .with_default_header(packet.packet_type, packet.delivery, packet.ordering);
+
+                    if let OrderingGuarantee::Sequenced(stream_id) = packet.ordering {
                         let item_identifier = self
                             .sequencing_system
                             .get_or_create_stream(stream_id.unwrap_or(DEFAULT_SEQUENCING_STREAM))
@@ -117,25 +202,24 @@ impl VirtualConnection {
                         builder = builder.with_sequencing_header(item_identifier as u16, stream_id);
                     };
 
-                    Ok(Outgoing::Packet(builder.build()))
+                    Ok(OutgoingPackets::one(builder.build()))
                 } else {
-                    Err(ErrorKind::PacketError(
-                        PacketErrorKind::ExceededMaxPacketSize,
-                    ))
+                    Err(PacketErrorKind::ExceededMaxPacketSize.into())
                 }
             }
             DeliveryGuarantee::Reliable => {
-                let payload_length = payload.len() as u16;
+                let payload_length = packet.payload.len() as u16;
 
                 let mut item_identifier_value = None;
                 let outgoing = {
                     // spit the packet if the payload length is greater than the allowed fragment size.
                     if payload_length <= self.config.fragment_size {
-                        let mut builder = OutgoingPacketBuilder::new(payload).with_default_header(
-                            PacketType::Packet,
-                            delivery_guarantee,
-                            ordering_guarantee,
-                        );
+                        let mut builder = OutgoingPacketBuilder::new(packet.payload)
+                            .with_default_header(
+                                packet.packet_type,
+                                packet.delivery,
+                                packet.ordering,
+                            );
 
                         builder = builder.with_acknowledgment_header(
                             self.acknowledge_handler.local_sequence_num(),
@@ -143,7 +227,7 @@ impl VirtualConnection {
                             self.acknowledge_handler.ack_bitfield(),
                         );
 
-                        if let OrderingGuarantee::Ordered(stream_id) = ordering_guarantee {
+                        if let OrderingGuarantee::Ordered(stream_id) = packet.ordering {
                             let item_identifier =
                                 if let Some(item_identifier) = last_item_identifier {
                                     item_identifier
@@ -160,7 +244,7 @@ impl VirtualConnection {
                             builder = builder.with_ordering_header(item_identifier, stream_id);
                         };
 
-                        if let OrderingGuarantee::Sequenced(stream_id) = ordering_guarantee {
+                        if let OrderingGuarantee::Sequenced(stream_id) = packet.ordering {
                             let item_identifier =
                                 if let Some(item_identifier) = last_item_identifier {
                                     item_identifier
@@ -177,10 +261,13 @@ impl VirtualConnection {
                             builder = builder.with_sequencing_header(item_identifier, stream_id);
                         };
 
-                        Outgoing::Packet(builder.build())
+                        OutgoingPackets::one(builder.build())
                     } else {
-                        Outgoing::Fragments(
-                            Fragmentation::spit_into_fragments(payload, &self.config)?
+                        if packet.packet_type != PacketType::Packet {
+                            return Err(PacketErrorKind::PacketCannotBeFragmented.into());
+                        }
+                        OutgoingPackets::many(
+                            Fragmentation::spit_into_fragments(packet.payload, &self.config)?
                                 .into_iter()
                                 .enumerate()
                                 .map(|(fragment_id, fragment)| {
@@ -192,9 +279,9 @@ impl VirtualConnection {
 
                                     let mut builder = OutgoingPacketBuilder::new(fragment)
                                         .with_default_header(
-                                            PacketType::Fragment,
-                                            delivery_guarantee,
-                                            ordering_guarantee,
+                                            PacketType::Fragment, // change from Packet to Fragment type, it only matters when assembling/dissasembling packet header.
+                                            packet.delivery,
+                                            packet.ordering,
                                         );
 
                                     builder = builder.with_fragment_header(
@@ -218,12 +305,12 @@ impl VirtualConnection {
                     }
                 };
 
-                self.last_sent = time;
                 self.congestion_handler
                     .process_outgoing(self.acknowledge_handler.local_sequence_num(), time);
                 self.acknowledge_handler.process_outgoing(
-                    payload,
-                    ordering_guarantee,
+                    packet.packet_type,
+                    packet.payload,
+                    packet.ordering,
                     item_identifier_value,
                 );
 
@@ -236,9 +323,8 @@ impl VirtualConnection {
     pub fn process_incoming(
         &mut self,
         received_data: &[u8],
-        sender: &Sender<SocketEvent>,
         time: Instant,
-    ) -> crate::Result<()> {
+    ) -> Result<IncomingPackets> {
         self.last_heard = time;
 
         let mut packet_reader = PacketReader::new(received_data);
@@ -252,7 +338,7 @@ impl VirtualConnection {
         if header.is_heartbeat() {
             // Heartbeat packets are unreliable, unordered and empty packets.
             // We already updated our `self.last_heard` time, nothing else to be done.
-            return Ok(());
+            return Ok(IncomingPackets::zero());
         }
 
         match header.delivery_guarantee() {
@@ -268,25 +354,29 @@ impl VirtualConnection {
                         .get_or_create_stream(arranging_header.stream_id());
 
                     if let Some(packet) = stream.arrange(arranging_header.arranging_id(), payload) {
-                        Self::queue_packet(
-                            sender,
-                            packet,
-                            self.remote_address,
-                            header.delivery_guarantee(),
-                            OrderingGuarantee::Sequenced(Some(arranging_header.stream_id())),
-                        )?;
+                        return Ok(IncomingPackets::one(
+                            Packet::new(
+                                self.remote_address,
+                                packet,
+                                header.delivery_guarantee(),
+                                OrderingGuarantee::Sequenced(Some(arranging_header.stream_id())),
+                            ),
+                            header.packet_type(),
+                        ));
                     }
 
-                    return Ok(());
+                    return Ok(IncomingPackets::zero());
                 }
 
-                Self::queue_packet(
-                    sender,
-                    packet_reader.read_payload(),
-                    self.remote_address,
-                    header.delivery_guarantee(),
-                    header.ordering_guarantee(),
-                )?;
+                return Ok(IncomingPackets::one(
+                    Packet::new(
+                        self.remote_address,
+                        packet_reader.read_payload(),
+                        header.delivery_guarantee(),
+                        header.ordering_guarantee(),
+                    ),
+                    header.packet_type(),
+                ));
             }
             DeliveryGuarantee::Reliable => {
                 if header.is_fragment() {
@@ -299,14 +389,6 @@ impl VirtualConnection {
                             acked_header,
                         ) {
                             Ok(Some((payload, acked_header))) => {
-                                Self::queue_packet(
-                                    sender,
-                                    payload.into_boxed_slice(),
-                                    self.remote_address,
-                                    header.delivery_guarantee(),
-                                    header.ordering_guarantee(),
-                                )?;
-
                                 self.congestion_handler
                                     .process_incoming(acked_header.sequence());
                                 self.acknowledge_handler.process_incoming(
@@ -314,13 +396,31 @@ impl VirtualConnection {
                                     acked_header.ack_seq(),
                                     acked_header.ack_field(),
                                 );
+
+                                return Ok(IncomingPackets::one(
+                                    Packet::new(
+                                        self.remote_address,
+                                        payload.into_boxed_slice(),
+                                        header.delivery_guarantee(),
+                                        header.ordering_guarantee(),
+                                    ),
+                                    PacketType::Packet, // change from Fragment to Packet type, it only matters when assembling/dissasembling packet header.
+                                ));
                             }
-                            Ok(None) => return Ok(()),
+                            Ok(None) => return Ok(IncomingPackets::zero()),
                             Err(e) => return Err(e),
                         };
                     }
                 } else {
                     let acked_header = packet_reader.read_acknowledge_header()?;
+
+                    self.congestion_handler
+                        .process_incoming(acked_header.sequence());
+                    self.acknowledge_handler.process_incoming(
+                        acked_header.sequence(),
+                        acked_header.ack_seq(),
+                        acked_header.ack_field(),
+                    );
 
                     if let OrderingGuarantee::Sequenced(_) = header.ordering_guarantee() {
                         let arranging_header = packet_reader.read_arranging_header(u16::from(
@@ -336,13 +436,17 @@ impl VirtualConnection {
                         if let Some(packet) =
                             stream.arrange(arranging_header.arranging_id(), payload)
                         {
-                            Self::queue_packet(
-                                sender,
-                                packet,
-                                self.remote_address,
-                                header.delivery_guarantee(),
-                                OrderingGuarantee::Sequenced(Some(arranging_header.stream_id())),
-                            )?;
+                            return Ok(IncomingPackets::one(
+                                Packet::new(
+                                    self.remote_address,
+                                    packet,
+                                    header.delivery_guarantee(),
+                                    OrderingGuarantee::Sequenced(Some(
+                                        arranging_header.stream_id(),
+                                    )),
+                                ),
+                                header.packet_type(),
+                            ));
                         }
                     } else if let OrderingGuarantee::Ordered(_id) = header.ordering_guarantee() {
                         let arranging_header = packet_reader.read_arranging_header(u16::from(
@@ -354,68 +458,46 @@ impl VirtualConnection {
                         let stream = self
                             .ordering_system
                             .get_or_create_stream(arranging_header.stream_id());
-
-                        if let Some(packet) =
-                            stream.arrange(arranging_header.arranging_id(), payload)
-                        {
-                            Self::queue_packet(
-                                sender,
-                                packet,
-                                self.remote_address,
-                                header.delivery_guarantee(),
-                                OrderingGuarantee::Ordered(Some(arranging_header.stream_id())),
-                            )?;
-
-                            while let Some(packet) = stream.iter_mut().next() {
-                                Self::queue_packet(
-                                    sender,
-                                    packet,
-                                    self.remote_address,
-                                    header.delivery_guarantee(),
-                                    OrderingGuarantee::Ordered(Some(arranging_header.stream_id())),
-                                )?;
-                            }
-                        }
+                        let address = self.remote_address;
+                        return Ok(IncomingPackets::many(
+                            stream
+                                .arrange(
+                                    arranging_header.arranging_id(),
+                                    (payload, header.packet_type()),
+                                )
+                                .into_iter()
+                                .chain(stream.iter_mut())
+                                .map(|(packet, packet_type)| {
+                                    (
+                                        Packet::new(
+                                            address,
+                                            packet,
+                                            header.delivery_guarantee(),
+                                            OrderingGuarantee::Ordered(Some(
+                                                arranging_header.stream_id(),
+                                            )),
+                                        ),
+                                        packet_type,
+                                    )
+                                })
+                                .collect(),
+                        ));
                     } else {
                         let payload = packet_reader.read_payload();
-
-                        Self::queue_packet(
-                            sender,
-                            payload,
-                            self.remote_address,
-                            header.delivery_guarantee(),
-                            header.ordering_guarantee(),
-                        )?;
+                        return Ok(IncomingPackets::one(
+                            Packet::new(
+                                self.remote_address,
+                                payload,
+                                header.delivery_guarantee(),
+                                header.ordering_guarantee(),
+                            ),
+                            header.packet_type(),
+                        ));
                     }
-
-                    self.congestion_handler
-                        .process_incoming(acked_header.sequence());
-                    self.acknowledge_handler.process_incoming(
-                        acked_header.sequence(),
-                        acked_header.ack_seq(),
-                        acked_header.ack_field(),
-                    );
                 }
             }
         }
-
-        Ok(())
-    }
-
-    fn queue_packet(
-        tx: &Sender<SocketEvent>,
-        payload: Box<[u8]>,
-        remote_addr: SocketAddr,
-        delivery: DeliveryGuarantee,
-        ordering: OrderingGuarantee,
-    ) -> Result<()> {
-        tx.send(SocketEvent::Packet(Packet::new(
-            remote_addr,
-            payload,
-            delivery,
-            ordering,
-        )))?;
-        Ok(())
+        Ok(IncomingPackets::zero())
     }
 
     /// This will gather dropped packets from the acknowledgment handler.
@@ -443,15 +525,46 @@ mod tests {
     use crate::config::Config;
     use crate::net::constants;
     use crate::packet::header::{AckedPacketHeader, ArrangingHeader, HeaderWriter, StandardHeader};
-    use crate::packet::{DeliveryGuarantee, OrderingGuarantee, Outgoing, Packet, PacketType};
+    use crate::packet::{DeliveryGuarantee, GenericPacket, OrderingGuarantee, Packet, PacketType};
     use crate::protocol_version::ProtocolVersion;
-    use crate::SocketEvent;
     use byteorder::{BigEndian, WriteBytesExt};
-    use crossbeam_channel::{unbounded, TryRecvError};
     use std::io::Write;
-    use std::time::Instant;
+    use std::time::{Duration, Instant};
 
     const PAYLOAD: [u8; 4] = [1, 2, 3, 4];
+
+    #[test]
+    fn set_last_sent_and_last_heard_when_processing() {
+        let mut connection = create_virtual_connection();
+        let curr_sent = connection.last_sent;
+        let curr_heard = connection.last_heard;
+
+        let out_packet = connection
+            .process_outgoing(
+                GenericPacket::heartbeat_packet(&[]),
+                None,
+                curr_sent + Duration::from_secs(1),
+            )
+            .unwrap()
+            .into_iter()
+            .next()
+            .unwrap();
+        let in_packet = connection
+            .process_incoming(&out_packet.contents(), curr_heard + Duration::from_secs(2))
+            .unwrap()
+            .into_iter()
+            .next();
+
+        assert_eq!(
+            connection.last_sent.duration_since(curr_sent),
+            Duration::from_secs(1)
+        );
+        assert_eq!(
+            connection.last_heard.duration_since(curr_heard),
+            Duration::from_secs(2)
+        );
+        assert_eq!(in_packet.is_none(), true);
+    }
 
     #[test]
     fn assure_right_fragmentation() {
@@ -467,20 +580,19 @@ mod tests {
         let second_fragment = vec![0, 0, 2, 4];
         let third_fragment = vec![0, 0, 3, 4];
 
-        let (tx, rx) = unbounded::<SocketEvent>();
-
         let mut connection = create_virtual_connection();
-        connection
+        let packet = connection
             .process_incoming(
                 [standard_header.as_slice(), acked_header.as_slice()]
                     .concat()
                     .as_slice(),
-                &tx,
                 Instant::now(),
             )
-            .unwrap();
-        assert!(rx.try_recv().is_err());
-        connection
+            .unwrap()
+            .into_iter()
+            .next();
+        assert!(packet.is_none());
+        let packet = connection
             .process_incoming(
                 [
                     standard_header.as_slice(),
@@ -489,12 +601,13 @@ mod tests {
                 ]
                 .concat()
                 .as_slice(),
-                &tx,
                 Instant::now(),
             )
-            .unwrap();
-        assert!(rx.try_recv().is_err());
-        connection
+            .unwrap()
+            .into_iter()
+            .next();
+        assert!(packet.is_none());
+        let packet = connection
             .process_incoming(
                 [
                     standard_header.as_slice(),
@@ -503,12 +616,13 @@ mod tests {
                 ]
                 .concat()
                 .as_slice(),
-                &tx,
                 Instant::now(),
             )
-            .unwrap();
-        assert!(rx.try_recv().is_err());
-        connection
+            .unwrap()
+            .into_iter()
+            .next();
+        assert!(packet.is_none());
+        let (packets, _) = connection
             .process_incoming(
                 [
                     standard_header.as_slice(),
@@ -517,22 +631,16 @@ mod tests {
                 ]
                 .concat()
                 .as_slice(),
-                &tx,
                 Instant::now(),
             )
+            .unwrap()
+            .into_iter()
+            .next()
             .unwrap();
-
-        let complete_fragment = rx.try_recv().unwrap();
-
-        match complete_fragment {
-            SocketEvent::Packet(fragment) => assert_eq!(
-                fragment.payload(),
-                &*[PAYLOAD, PAYLOAD, PAYLOAD].concat().into_boxed_slice()
-            ),
-            _ => {
-                panic!("Expected fragment other result.");
-            }
-        }
+        assert_eq!(
+            packets.payload(),
+            &*[PAYLOAD, PAYLOAD, PAYLOAD].concat().into_boxed_slice()
+        );
     }
 
     #[test]
@@ -541,22 +649,20 @@ mod tests {
 
         let buffer = vec![1; 4000];
 
-        let outgoing = connection
+        let packets: Vec<_> = connection
             .process_outgoing(
-                &buffer,
-                DeliveryGuarantee::Reliable,
-                OrderingGuarantee::Ordered(None),
+                GenericPacket::user_packet(
+                    &buffer,
+                    DeliveryGuarantee::Reliable,
+                    OrderingGuarantee::Ordered(None),
+                ),
                 None,
                 Instant::now(),
             )
-            .unwrap();
-
-        match outgoing {
-            Outgoing::Packet(_) => panic!("Expected fragment got packet"),
-            Outgoing::Fragments(fragments) => {
-                assert_eq!(fragments.len(), 4);
-            }
-        }
+            .unwrap()
+            .into_iter()
+            .collect();
+        assert_eq!(packets.len(), 4);
     }
 
     #[test]
@@ -567,9 +673,11 @@ mod tests {
 
         connection
             .process_outgoing(
-                &buffer,
-                DeliveryGuarantee::Unreliable,
-                OrderingGuarantee::None,
+                GenericPacket::user_packet(
+                    &buffer,
+                    DeliveryGuarantee::Unreliable,
+                    OrderingGuarantee::None,
+                ),
                 None,
                 Instant::now(),
             )
@@ -577,9 +685,11 @@ mod tests {
 
         connection
             .process_outgoing(
-                &buffer,
-                DeliveryGuarantee::Unreliable,
-                OrderingGuarantee::Sequenced(None),
+                GenericPacket::user_packet(
+                    &buffer,
+                    DeliveryGuarantee::Unreliable,
+                    OrderingGuarantee::Sequenced(None),
+                ),
                 None,
                 Instant::now(),
             )
@@ -587,9 +697,11 @@ mod tests {
 
         connection
             .process_outgoing(
-                &buffer,
-                DeliveryGuarantee::Reliable,
-                OrderingGuarantee::Ordered(None),
+                GenericPacket::user_packet(
+                    &buffer,
+                    DeliveryGuarantee::Reliable,
+                    OrderingGuarantee::Ordered(None),
+                ),
                 None,
                 Instant::now(),
             )
@@ -597,9 +709,11 @@ mod tests {
 
         connection
             .process_outgoing(
-                &buffer,
-                DeliveryGuarantee::Reliable,
-                OrderingGuarantee::Sequenced(None),
+                GenericPacket::user_packet(
+                    &buffer,
+                    DeliveryGuarantee::Reliable,
+                    OrderingGuarantee::Sequenced(None),
+                ),
                 None,
                 Instant::now(),
             )
@@ -614,11 +728,11 @@ mod tests {
             DeliveryGuarantee::Unreliable,
             OrderingGuarantee::Sequenced(Some(1)),
             &mut connection,
-            Ok(SocketEvent::Packet(Packet::unreliable_sequenced(
+            Some(Packet::unreliable_sequenced(
                 get_fake_addr(),
                 PAYLOAD.to_vec(),
                 Some(1),
-            ))),
+            )),
             1,
         );
 
@@ -626,11 +740,11 @@ mod tests {
             DeliveryGuarantee::Unreliable,
             OrderingGuarantee::Sequenced(Some(1)),
             &mut connection,
-            Ok(SocketEvent::Packet(Packet::unreliable_sequenced(
+            Some(Packet::unreliable_sequenced(
                 get_fake_addr(),
                 PAYLOAD.to_vec(),
                 Some(1),
-            ))),
+            )),
             3,
         );
 
@@ -638,7 +752,7 @@ mod tests {
             DeliveryGuarantee::Unreliable,
             OrderingGuarantee::Sequenced(Some(1)),
             &mut connection,
-            Err(TryRecvError::Empty),
+            None,
             2,
         );
 
@@ -646,11 +760,11 @@ mod tests {
             DeliveryGuarantee::Unreliable,
             OrderingGuarantee::Sequenced(Some(1)),
             &mut connection,
-            Ok(SocketEvent::Packet(Packet::unreliable_sequenced(
+            Some(Packet::unreliable_sequenced(
                 get_fake_addr(),
                 PAYLOAD.to_vec(),
                 Some(1),
-            ))),
+            )),
             4,
         );
 
@@ -658,11 +772,11 @@ mod tests {
             DeliveryGuarantee::Reliable,
             OrderingGuarantee::Sequenced(Some(1)),
             &mut connection,
-            Ok(SocketEvent::Packet(Packet::reliable_sequenced(
+            Some(Packet::reliable_sequenced(
                 get_fake_addr(),
                 PAYLOAD.to_vec(),
                 Some(1),
-            ))),
+            )),
             5,
         );
     }
@@ -675,11 +789,11 @@ mod tests {
             DeliveryGuarantee::Reliable,
             OrderingGuarantee::Ordered(Some(1)),
             &mut connection,
-            Ok(SocketEvent::Packet(Packet::reliable_ordered(
+            Some(Packet::reliable_ordered(
                 get_fake_addr(),
                 PAYLOAD.to_vec(),
                 Some(1),
-            ))),
+            )),
             0,
         );
 
@@ -687,7 +801,7 @@ mod tests {
             DeliveryGuarantee::Reliable,
             OrderingGuarantee::Ordered(Some(1)),
             &mut connection,
-            Err(TryRecvError::Empty),
+            None,
             2,
         );
 
@@ -695,7 +809,7 @@ mod tests {
             DeliveryGuarantee::Reliable,
             OrderingGuarantee::Ordered(Some(1)),
             &mut connection,
-            Err(TryRecvError::Empty),
+            None,
             3,
         );
 
@@ -703,11 +817,11 @@ mod tests {
             DeliveryGuarantee::Reliable,
             OrderingGuarantee::Ordered(Some(1)),
             &mut connection,
-            Ok(SocketEvent::Packet(Packet::reliable_ordered(
+            Some(Packet::reliable_ordered(
                 get_fake_addr(),
                 PAYLOAD.to_vec(),
                 Some(1),
-            ))),
+            )),
             1,
         );
     }
@@ -719,27 +833,24 @@ mod tests {
         assert_incoming_without_order(
             DeliveryGuarantee::Unreliable,
             &mut connection,
-            SocketEvent::Packet(Packet::unreliable(get_fake_addr(), PAYLOAD.to_vec())),
+            Packet::unreliable(get_fake_addr(), PAYLOAD.to_vec()),
         );
 
         assert_incoming_without_order(
             DeliveryGuarantee::Reliable,
             &mut connection,
-            SocketEvent::Packet(Packet::reliable_unordered(
-                get_fake_addr(),
-                PAYLOAD.to_vec(),
-            )),
+            Packet::reliable_unordered(get_fake_addr(), PAYLOAD.to_vec()),
         );
 
         assert_incoming_with_order(
             DeliveryGuarantee::Unreliable,
             OrderingGuarantee::Sequenced(Some(1)),
             &mut connection,
-            Ok(SocketEvent::Packet(Packet::unreliable_sequenced(
+            Some(Packet::unreliable_sequenced(
                 get_fake_addr(),
                 PAYLOAD.to_vec(),
                 Some(1),
-            ))),
+            )),
             1,
         );
 
@@ -747,11 +858,11 @@ mod tests {
             DeliveryGuarantee::Reliable,
             OrderingGuarantee::Ordered(Some(1)),
             &mut connection,
-            Ok(SocketEvent::Packet(Packet::reliable_ordered(
+            Some(Packet::reliable_ordered(
                 get_fake_addr(),
                 PAYLOAD.to_vec(),
                 Some(1),
-            ))),
+            )),
             0,
         );
     }
@@ -793,8 +904,6 @@ mod tests {
 
         let acked_header = vec![0, 0, 255, 4, 0, 0, 255, 255, 0, 0, 0, 0];
 
-        let (tx, _rx) = unbounded::<SocketEvent>();
-
         use crate::error::{ErrorKind, FragmentErrorKind};
 
         let mut connection = create_virtual_connection();
@@ -802,7 +911,6 @@ mod tests {
             [standard_header.as_slice(), acked_header.as_slice()]
                 .concat()
                 .as_slice(),
-            &tx,
             Instant::now(),
         );
 
@@ -830,7 +938,7 @@ mod tests {
         delivery: DeliveryGuarantee,
         ordering: OrderingGuarantee,
         connection: &mut VirtualConnection,
-        result_event: Result<SocketEvent, TryRecvError>,
+        result_packet: Option<Packet>,
         order_id: u16,
     ) {
         let mut packet = Vec::new();
@@ -867,25 +975,20 @@ mod tests {
 
         packet.write_all(&PAYLOAD).unwrap();
 
-        let (tx, rx) = unbounded::<SocketEvent>();
-
-        connection
-            .process_incoming(packet.as_slice(), &tx, Instant::now())
-            .unwrap();
-
-        let event = rx.try_recv();
-
-        match event {
-            Ok(val) => assert_eq!(val, result_event.unwrap()),
-            Err(e) => assert_eq!(e, result_event.err().unwrap()),
-        }
+        let packets = connection
+            .process_incoming(packet.as_slice(), Instant::now())
+            .unwrap()
+            .into_iter()
+            .next()
+            .map(|(packet, _)| packet);
+        assert_eq!(packets, result_packet);
     }
 
-    // assert that the given `DeliveryGuarantee` results into the given `SocketEvent` after processing.
+    // assert that the given `DeliveryGuarantee` results into the given `Packet` after processing.
     fn assert_incoming_without_order(
         delivery: DeliveryGuarantee,
         connection: &mut VirtualConnection,
-        result_event: SocketEvent,
+        result_packet: Packet,
     ) {
         let mut packet = Vec::new();
 
@@ -900,15 +1003,14 @@ mod tests {
 
         packet.write_all(&PAYLOAD).unwrap();
 
-        let (tx, rx) = unbounded::<SocketEvent>();
-
-        connection
-            .process_incoming(packet.as_slice(), &tx, Instant::now())
+        let (packet, _) = connection
+            .process_incoming(packet.as_slice(), Instant::now())
+            .unwrap()
+            .into_iter()
+            .next()
             .unwrap();
 
-        let event = rx.try_recv();
-
-        assert_eq!(event, Ok(result_event));
+        assert_eq!(packet, result_packet);
     }
 
     // assert that the size of the processed header is the same as the given one.
@@ -922,14 +1024,19 @@ mod tests {
         let buffer = vec![1; 500];
 
         let outgoing = connection
-            .process_outgoing(&buffer, delivery, ordering, None, Instant::now())
+            .process_outgoing(
+                GenericPacket::user_packet(&buffer, delivery, ordering),
+                None,
+                Instant::now(),
+            )
             .unwrap();
-
-        match outgoing {
-            Outgoing::Packet(packet) => {
-                assert_eq!(packet.contents().len() - buffer.len(), expected_header_size);
-            }
-            Outgoing::Fragments(_) => panic!("Expected packet got fragment"),
+        let mut iter = outgoing.into_iter();
+        assert_eq!(
+            iter.next().unwrap().contents().len() - buffer.len(),
+            expected_header_size
+        );
+        if iter.next().is_some() {
+            panic!("Expected not fragmented packet")
         }
     }
 }

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -6,11 +6,13 @@ mod enums;
 mod outgoing;
 mod packet_reader;
 mod packet_structure;
+mod process_result;
 
 pub use self::enums::{DeliveryGuarantee, OrderingGuarantee, PacketType};
 pub use self::outgoing::{OutgoingPacket, OutgoingPacketBuilder};
 pub use self::packet_reader::PacketReader;
-pub use self::packet_structure::{GenericPacket, Packet};
+pub use self::packet_structure::{Packet, PacketInfo};
+pub use self::process_result::{IncomingPackets, OutgoingPackets};
 
 pub type SequenceNumber = u16;
 

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -8,9 +8,9 @@ mod packet_reader;
 mod packet_structure;
 
 pub use self::enums::{DeliveryGuarantee, OrderingGuarantee, PacketType};
-pub use self::outgoing::{Outgoing, OutgoingPacket, OutgoingPacketBuilder};
+pub use self::outgoing::{OutgoingPacket, OutgoingPacketBuilder};
 pub use self::packet_reader::PacketReader;
-pub use self::packet_structure::Packet;
+pub use self::packet_structure::{GenericPacket, Packet};
 
 pub type SequenceNumber = u16;
 

--- a/src/packet/header/standard_header.rs
+++ b/src/packet/header/standard_header.rs
@@ -48,7 +48,6 @@ impl StandardHeader {
     }
 
     /// Returns the PacketType
-    #[cfg(test)]
     pub fn packet_type(&self) -> PacketType {
         self.packet_type
     }

--- a/src/packet/outgoing.rs
+++ b/src/packet/outgoing.rs
@@ -122,14 +122,6 @@ impl<'p> OutgoingPacket<'p> {
     }
 }
 
-/// Enum for storing different kinds of outgoing types with data.
-pub enum Outgoing<'a> {
-    /// Represents a single packet.
-    Packet(OutgoingPacket<'a>),
-    /// Represents a packet that is fragmented and thus contains more than one `OutgoingPacket`.
-    Fragments(Vec<OutgoingPacket<'a>>),
-}
-
 #[cfg(test)]
 mod tests {
     use crate::packet::PacketType;

--- a/src/packet/packet_structure.rs
+++ b/src/packet/packet_structure.rs
@@ -179,6 +179,7 @@ impl Packet {
 /// This packet type has similar properties to `Packet` except that it doesn't own anything, and additionally has `PacketType`.
 #[derive(Debug)]
 pub struct PacketInfo<'a> {
+    /// defines a type of the packet
     pub(crate) packet_type: PacketType,
     /// the raw payload of the packet
     pub(crate) payload: &'a [u8],

--- a/src/packet/packet_structure.rs
+++ b/src/packet/packet_structure.rs
@@ -190,7 +190,7 @@ pub struct PacketInfo<'a> {
 }
 
 impl<'a> PacketInfo<'a> {
-    /// This will create a user packet that can be received by the user.
+    /// Creates a user packet that can be received by the user.
     pub fn user_packet(
         payload: &'a [u8],
         delivery: DeliveryGuarantee,
@@ -204,7 +204,7 @@ impl<'a> PacketInfo<'a> {
         }
     }
 
-    /// This will create a heartbeat packet that is expected to be sent over the network
+    /// Creates a heartbeat packet that is expected to be sent over the network.
     pub fn heartbeat_packet(payload: &'a [u8]) -> Self {
         PacketInfo {
             packet_type: PacketType::Heartbeat,

--- a/src/packet/packet_structure.rs
+++ b/src/packet/packet_structure.rs
@@ -1,4 +1,4 @@
-use crate::packet::{DeliveryGuarantee, OrderingGuarantee};
+use crate::packet::{DeliveryGuarantee, OrderingGuarantee, PacketType};
 use std::net::SocketAddr;
 
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -173,6 +173,44 @@ impl Packet {
     /// Returns the [`OrderingGuarantee`](./enum.OrderingGuarantee.html) of this packet.
     pub fn order_guarantee(&self) -> OrderingGuarantee {
         self.ordering
+    }
+}
+
+/// This packet type has similar properties to `Packet` except that it doesn't own anything, and additionally has `PacketType`.
+#[derive(Debug)]
+pub struct GenericPacket<'a> {
+    pub(crate) packet_type: PacketType,
+    /// the raw payload of the packet
+    pub(crate) payload: &'a [u8],
+    /// defines on how the packet will be delivered.
+    pub(crate) delivery: DeliveryGuarantee,
+    /// defines on how the packet will be ordered.
+    pub(crate) ordering: OrderingGuarantee,
+}
+
+impl<'a> GenericPacket<'a> {
+    /// This will create a user packet that can be received by the user.
+    pub fn user_packet(
+        payload: &'a [u8],
+        delivery: DeliveryGuarantee,
+        ordering: OrderingGuarantee,
+    ) -> Self {
+        Self {
+            packet_type: PacketType::Packet,
+            payload,
+            delivery,
+            ordering,
+        }
+    }
+
+    /// This will create a heartbeat packet that is expected to be sent over the network
+    pub fn heartbeat_packet(payload: &'a [u8]) -> Self {
+        Self {
+            packet_type: PacketType::Heartbeat,
+            payload,
+            delivery: DeliveryGuarantee::Unreliable,
+            ordering: OrderingGuarantee::None,
+        }
     }
 }
 

--- a/src/packet/packet_structure.rs
+++ b/src/packet/packet_structure.rs
@@ -178,7 +178,7 @@ impl Packet {
 
 /// This packet type has similar properties to `Packet` except that it doesn't own anything, and additionally has `PacketType`.
 #[derive(Debug)]
-pub struct GenericPacket<'a> {
+pub struct PacketInfo<'a> {
     pub(crate) packet_type: PacketType,
     /// the raw payload of the packet
     pub(crate) payload: &'a [u8],
@@ -188,14 +188,14 @@ pub struct GenericPacket<'a> {
     pub(crate) ordering: OrderingGuarantee,
 }
 
-impl<'a> GenericPacket<'a> {
+impl<'a> PacketInfo<'a> {
     /// This will create a user packet that can be received by the user.
     pub fn user_packet(
         payload: &'a [u8],
         delivery: DeliveryGuarantee,
         ordering: OrderingGuarantee,
     ) -> Self {
-        Self {
+        PacketInfo {
             packet_type: PacketType::Packet,
             payload,
             delivery,
@@ -205,7 +205,7 @@ impl<'a> GenericPacket<'a> {
 
     /// This will create a heartbeat packet that is expected to be sent over the network
     pub fn heartbeat_packet(payload: &'a [u8]) -> Self {
-        Self {
+        PacketInfo {
             packet_type: PacketType::Heartbeat,
             payload,
             delivery: DeliveryGuarantee::Unreliable,

--- a/src/packet/packet_structure.rs
+++ b/src/packet/packet_structure.rs
@@ -182,9 +182,9 @@ pub struct GenericPacket<'a> {
     pub(crate) packet_type: PacketType,
     /// the raw payload of the packet
     pub(crate) payload: &'a [u8],
-    /// defines on how the packet will be delivered.
+    /// defines how the packet will be delivered.
     pub(crate) delivery: DeliveryGuarantee,
-    /// defines on how the packet will be ordered.
+    /// defines how the packet will be ordered.
     pub(crate) ordering: OrderingGuarantee,
 }
 

--- a/src/packet/process_result.rs
+++ b/src/packet/process_result.rs
@@ -3,8 +3,8 @@ use crate::packet::{OutgoingPacket, Packet, PacketType};
 
 use std::collections::VecDeque;
 
-/// Helper class that implements `Iterator`, and is used to return incoming (from bytes to packets) or outgoing (from packet to bytes) packets.
-/// It is used as optimization in cases, where most of the time there is only one element to iterate, and we don't want to create a vector for it
+/// Struct that implements `Iterator`, and is used to return incoming (from bytes to packets) or outgoing (from packet to bytes) packets.
+/// It is used as optimization in cases, where most of the time there is only one element to iterate, and we don't want to create a vector for it.
 pub struct ZeroOrMore<T> {
     data: Either<Option<T>, VecDeque<T>>,
 }
@@ -46,14 +46,14 @@ pub struct OutgoingPackets<'a> {
 }
 
 impl<'a> OutgoingPackets<'a> {
-    /// Store only one packet, without allocating on the heap
+    /// Stores only one packet, without allocating on the heap.
     pub fn one(packet: OutgoingPacket<'a>) -> Self {
         Self {
             data: ZeroOrMore::one(packet),
         }
     }
 
-    /// Store multiple packets, allocated on the heap
+    /// Stores multiple packets, allocated on the heap.
     pub fn many(packets: VecDeque<OutgoingPacket<'a>>) -> Self {
         Self {
             data: ZeroOrMore::many(packets),
@@ -83,14 +83,14 @@ impl IncomingPackets {
         }
     }
 
-    /// Store only one packet, without allocating on the heap
+    /// Stores only one packet, without allocating on the heap.
     pub fn one(packet: Packet, packet_type: PacketType) -> Self {
         Self {
             data: ZeroOrMore::one((packet, packet_type)),
         }
     }
 
-    /// Store multiple packets, allocated on the heap
+    /// Stores multiple packets, allocated on the heap.
     pub fn many(vec: VecDeque<(Packet, PacketType)>) -> Self {
         Self {
             data: ZeroOrMore::many(vec),

--- a/src/packet/process_result.rs
+++ b/src/packet/process_result.rs
@@ -2,6 +2,7 @@ use crate::either::Either;
 use crate::packet::{OutgoingPacket, Packet, PacketType};
 
 use std::collections::VecDeque;
+
 /// Helper class that implements `Iterator`, and is used to return incoming (from bytes to packets) or outgoing (from packet to bytes) packets.
 /// It is used as optimization in cases, where most of the time there is only one element to iterate, and we don't want to create a vector for it
 pub struct ZeroOrMore<T> {
@@ -39,18 +40,20 @@ impl<T> Iterator for ZeroOrMore<T> {
     }
 }
 
-/// Stores packets with headers that will be sent to the network
+/// Stores packets with headers that will be sent to the network, implements `IntoIterator` for convenience.
 pub struct OutgoingPackets<'a> {
     data: ZeroOrMore<OutgoingPacket<'a>>,
 }
 
 impl<'a> OutgoingPackets<'a> {
+    /// Store only one packet, without allocating on the heap
     pub fn one(packet: OutgoingPacket<'a>) -> Self {
         Self {
             data: ZeroOrMore::one(packet),
         }
     }
 
+    /// Store multiple packets, allocated on the heap
     pub fn many(packets: VecDeque<OutgoingPacket<'a>>) -> Self {
         Self {
             data: ZeroOrMore::many(packets),
@@ -67,24 +70,27 @@ impl<'a> IntoIterator for OutgoingPackets<'a> {
     }
 }
 
-/// Stores parsed packets with their types, that was received from network
+/// Stores parsed packets with their types, that was received from network, implements `IntoIterator` for convenience.
 pub struct IncomingPackets {
     data: ZeroOrMore<(Packet, PacketType)>,
 }
 
 impl IncomingPackets {
+    /// No packets are stored
     pub fn zero() -> Self {
         Self {
             data: ZeroOrMore::zero(),
         }
     }
 
+    /// Store only one packet, without allocating on the heap
     pub fn one(packet: Packet, packet_type: PacketType) -> Self {
         Self {
             data: ZeroOrMore::one((packet, packet_type)),
         }
     }
 
+    /// Store multiple packets, allocated on the heap
     pub fn many(vec: VecDeque<(Packet, PacketType)>) -> Self {
         Self {
             data: ZeroOrMore::many(vec),


### PR DESCRIPTION
Overall codebase improvements:
* Most changes are in `VirtualConnection` struct to make `process_incoming` and `process_outgoing` results make iterable.
* Introduced a new `PacketInfo` type.
* Bugfix covered by a test, when `last_sent`, was not set when sending `Unreliable` packets.
* Removed a lot of warnings when running `cargo clippy --tests`.

This PR will allow for much easier #246 integration.