### PR TITLE
clippy warnings for tests

### DIFF
--- a/src/infrastructure/acknowledgment.rs
+++ b/src/infrastructure/acknowledgment.rs
@@ -263,7 +263,10 @@ mod test {
         // Ack reads from right to left. So we know we have 99 since it's the last one we received.
         // Then, the first bit is acking 98, then 97, then we're missing 96 which makes sense
         // because 96 is evenly divisible by 4 and so on...
-        assert_eq!(handler.ack_bitfield(), 0b10111011101110111011101110111011);
+        assert_eq!(
+            handler.ack_bitfield(),
+            0b1011_1011_1011_1011_1011_1011_1011_1011
+        );
         assert_eq!(handler.dropped_packets().len(), 17);
     }
 

--- a/src/infrastructure/congestion.rs
+++ b/src/infrastructure/congestion.rs
@@ -60,7 +60,10 @@ mod test {
     fn rtt_value_is_updated() {
         let mut congestion_handler = CongestionHandler::new(&Config::default());
 
-        assert_eq!(congestion_handler.rtt_measurer.get_rtt(), 0.);
+        assert_eq!(
+            congestion_handler.rtt_measurer.get_rtt().abs() < std::f32::EPSILON,
+            true
+        );
         congestion_handler.process_outgoing(1, Instant::now());
         congestion_handler.process_incoming(1);
         assert_eq!(congestion_handler.rtt_measurer.get_rtt() != 0., true);

--- a/src/infrastructure/fragmenter.rs
+++ b/src/infrastructure/fragmenter.rs
@@ -71,7 +71,7 @@ impl Fragmentation {
             Fragmentation::fragments_needed(payload_length, config.fragment_size) as u8;
 
         if num_fragments > config.max_fragments {
-            Err(FragmentErrorKind::ExceededMaxFragments)?;
+            return Err(FragmentErrorKind::ExceededMaxFragments.into());
         }
 
         for fragment_id in 0..num_fragments {
@@ -113,20 +113,20 @@ impl Fragmentation {
             // get entry of previous received fragments
             let reassembly_data = match self.fragments.get_mut(fragment_header.sequence()) {
                 Some(val) => val,
-                None => Err(FragmentErrorKind::CouldNotFindFragmentById)?,
+                None => return Err(FragmentErrorKind::CouldNotFindFragmentById.into()),
             };
 
             // Got the data
             if reassembly_data.num_fragments_total != fragment_header.fragment_count() {
-                Err(FragmentErrorKind::FragmentWithUnevenNumberOfFragments)?
+                return Err(FragmentErrorKind::FragmentWithUnevenNumberOfFragments.into());
             }
 
             if usize::from(fragment_header.id()) >= reassembly_data.fragments_received.len() {
-                Err(FragmentErrorKind::ExceededMaxFragments)?;
+                return Err(FragmentErrorKind::ExceededMaxFragments.into());
             }
 
             if reassembly_data.fragments_received[usize::from(fragment_header.id())] {
-                Err(FragmentErrorKind::AlreadyProcessedFragment)?
+                return Err(FragmentErrorKind::AlreadyProcessedFragment.into());
             }
 
             // increase number of received fragments and set the specific fragment to received.
@@ -140,7 +140,7 @@ impl Fragmentation {
                 if reassembly_data.acked_header.is_none() {
                     reassembly_data.acked_header = Some(acked_header);
                 } else {
-                    Err(FragmentErrorKind::MultipleAckHeaders)?;
+                    return Err(FragmentErrorKind::MultipleAckHeaders.into());
                 }
             }
 
@@ -155,13 +155,13 @@ impl Fragmentation {
             let sequence = sequence as u16;
             if let Some(mut reassembly_data) = self.fragments.remove(sequence) {
                 if reassembly_data.acked_header.is_none() {
-                    Err(FragmentErrorKind::MissingAckHeader)?;
+                    return Err(FragmentErrorKind::MissingAckHeader.into());
                 }
 
                 let acked_header = reassembly_data.acked_header.take().unwrap();
                 return Ok(Some((total_buffer, acked_header)));
             } else {
-                Err(FragmentErrorKind::CouldNotFindFragmentById)?;
+                return Err(FragmentErrorKind::CouldNotFindFragmentById.into());
             }
         }
 

--- a/src/net/quality.rs
+++ b/src/net/quality.rs
@@ -36,7 +36,7 @@ impl RttMeasurer {
 
     #[cfg(test)]
     pub fn get_rtt(&self) -> f32 {
-        return self.rtt;
+        self.rtt
     }
 
     /// This will get the smoothed round trip time (rtt) from the time we last heard from a packet.
@@ -84,8 +84,8 @@ mod test {
     use std::net::ToSocketAddrs;
     use std::time::{Duration, Instant};
 
-    static TEST_HOST_IP: &'static str = "127.0.0.1";
-    static TEST_PORT: &'static str = "20000";
+    static TEST_HOST_IP: &str = "127.0.0.1";
+    static TEST_PORT: &str = "20000";
 
     #[test]
     fn test_create_connection() {
@@ -119,6 +119,6 @@ mod test {
         let smoothed_rtt = network_quality.smooth_out_rtt(300);
 
         // 300ms has exceeded 50ms over the max allowed rtt. So we check if or smoothing factor is now 10% from 50.
-        assert_eq!(smoothed_rtt, 5.0);
+        assert_eq!((smoothed_rtt - 5.0f32).abs() < std::f32::EPSILON, true);
     }
 }

--- a/src/net/virtual_connection.rs
+++ b/src/net/virtual_connection.rs
@@ -793,7 +793,7 @@ mod tests {
 
         let acked_header = vec![0, 0, 255, 4, 0, 0, 255, 255, 0, 0, 0, 0];
 
-        let (tx, rx) = unbounded::<SocketEvent>();
+        let (tx, _rx) = unbounded::<SocketEvent>();
 
         use crate::error::{ErrorKind, FragmentErrorKind};
 

--- a/src/packet/outgoing.rs
+++ b/src/packet/outgoing.rs
@@ -136,7 +136,7 @@ mod tests {
     use crate::packet::{DeliveryGuarantee, OrderingGuarantee, OutgoingPacketBuilder};
 
     fn test_payload() -> Vec<u8> {
-        return "test".as_bytes().to_vec();
+        b"test".to_vec()
     }
 
     #[test]

--- a/src/packet/packet_reader.rs
+++ b/src/packet/packet_reader.rs
@@ -204,7 +204,7 @@ mod tests {
         let mut reader = PacketReader::new(reliable_ordered_payload.as_slice());
 
         let arranging_header = reader
-            .read_arranging_header(StandardHeader::size() as u16)
+            .read_arranging_header(u16::from(StandardHeader::size()))
             .unwrap();
 
         assert_eq!(arranging_header.arranging_id(), 1);
@@ -225,7 +225,9 @@ mod tests {
         let standard_header = reader.read_standard_header().unwrap();
         let acked_header = reader.read_acknowledge_header().unwrap();
         let arranging_header = reader
-            .read_arranging_header((StandardHeader::size() + AckedPacketHeader::size()) as u16)
+            .read_arranging_header(u16::from(
+                StandardHeader::size() + AckedPacketHeader::size(),
+            ))
             .unwrap();
 
         assert_eq!(standard_header.protocol_version(), 1);

--- a/src/packet/packet_structure.rs
+++ b/src/packet/packet_structure.rs
@@ -241,7 +241,7 @@ mod tests {
     }
 
     fn test_payload() -> Vec<u8> {
-        return "test".as_bytes().to_vec();
+        b"test".to_vec()
     }
 
     fn test_addr() -> SocketAddr {

--- a/src/protocol_version.rs
+++ b/src/protocol_version.rs
@@ -45,7 +45,7 @@ mod test {
 
     #[test]
     fn not_valid_version() {
-        let protocol_id = crc16::checksum_x25("not-laminar".as_bytes());
+        let protocol_id = crc16::checksum_x25(b"not-laminar");
         assert!(!ProtocolVersion::valid_version(protocol_id));
     }
 


### PR DESCRIPTION
Fixed `cargo clippy --tests`.
Non-trivial fixes include:
* few floats compares. (error: `strict comparison of f32 or f64`)
* few macros were rewritten. (warning: `the function has a cognitive complexity of <N>`)