### PR TITLE
WIP connection factory

### DIFF
--- a/examples/udp.rs
+++ b/examples/udp.rs
@@ -40,14 +40,13 @@ pub fn receive_data() {
         if let Some(result) = socket.recv() {
             match result {
                 SocketEvent::Packet(packet) => {
-                    let endpoint: SocketAddr = packet.addr();
                     let received_data: &[u8] = packet.payload();
 
                     // you can here deserialize your bytes into the data you have passed it when sending.
 
                     println!(
                         "Received packet from: {:?} with length {}",
-                        endpoint,
+                        packet.addr(),
                         received_data.len()
                     );
                 }

--- a/src/net.rs
+++ b/src/net.rs
@@ -1,21 +1,26 @@
 //! This module provides the logic between the low-level abstract types and the types that the user will be interacting with.
 //! You can think of the socket, connection management, congestion control.
 
-pub use self::connection::{Connection, ConnectionEventAddress, ConnectionMessenger};
+pub use self::connection::{Connection, ConnectionFactory, ConnectionMessenger};
+pub use self::connection_impl::ConnectionImpl;
 pub use self::connection_manager::{ConnectionManager, DatagramSocket};
 pub use self::events::SocketEvent;
+pub use self::factory_impl::FactoryImpl;
 pub use self::link_conditioner::LinkConditioner;
 pub use self::quality::{NetworkQuality, RttMeasurer};
 pub use self::socket::Socket;
+pub use self::socket_with_conditioner::SocketWithConditioner;
 pub use self::virtual_connection::VirtualConnection;
 
 mod connection;
 mod connection_impl;
 mod connection_manager;
 mod events;
+mod factory_impl;
 mod link_conditioner;
 mod quality;
 mod socket;
+mod socket_with_conditioner;
 mod virtual_connection;
 
 pub mod constants;

--- a/src/net/factory_impl.rs
+++ b/src/net/factory_impl.rs
@@ -1,0 +1,181 @@
+use crate::config::Config;
+use crate::net::{Connection, ConnectionFactory};
+use crate::packet::Packet;
+
+use super::{ConnectionImpl, VirtualConnection};
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::time::{Duration, Instant};
+
+/// Interval before connection is banned if not accepted
+const NON_ACCEPT_TIMEOUT: Duration = Duration::from_secs(1);
+/// Interval how long connection is banned, after it was not accepted
+const TEMPORARY_BAN_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Provides simple DDoS protection by auto disconnecting non accepted connections, and ban them for some time.
+#[derive(Debug)]
+pub struct FactoryImpl {
+    config: Config,
+    temporary_banned: HashMap<SocketAddr, Instant>,
+}
+
+impl FactoryImpl {
+    pub fn new(config: Config) -> Self {
+        FactoryImpl {
+            config,
+            temporary_banned: Default::default(),
+        }
+    }
+
+    fn should_accept(
+        &mut self,
+        time: Instant,
+        address: SocketAddr,
+        non_accepted_timeout: Option<Instant>,
+    ) -> Option<ConnectionImpl> {
+        if let Some(banned_until) = self.temporary_banned.get(&address).copied() {
+            if non_accepted_timeout.is_none() {
+                self.temporary_banned.remove(&address);
+            } else if banned_until > time {
+                return None;
+            }
+        }
+        Some(ConnectionImpl {
+            non_accepted_timeout,
+            conn: VirtualConnection::new(address, &self.config, time),
+        })
+    }
+}
+
+impl ConnectionFactory for FactoryImpl {
+    type Connection = ConnectionImpl;
+
+    fn address_from_user_event<'s, 'a>(&'s self, event: &'a Packet) -> Option<&'a SocketAddr>
+    where
+        's: 'a,
+    {
+        Some(&event.addr)
+    }
+
+    /// Accepts connection if not banned.
+    fn should_accept_remote(
+        &mut self,
+        time: Instant,
+        address: SocketAddr,
+        _data: &[u8],
+    ) -> Option<Self::Connection> {
+        self.should_accept(time, address, Some(time + NON_ACCEPT_TIMEOUT))
+    }
+
+    /// Accepts connection if not banned.
+    fn should_accept_local(
+        &mut self,
+        time: Instant,
+        address: SocketAddr,
+        _event: &<Self::Connection as Connection>::UserEvent,
+    ) -> Option<Self::Connection> {
+        self.should_accept(time, address, None)
+    }
+
+    /// Removes addresses from ban list.
+    fn update(&mut self, time: Instant, _connections: &mut HashMap<SocketAddr, Self::Connection>) {
+        self.temporary_banned
+            .retain(|_, banned_until| *banned_until > time);
+    }
+
+    /// Discards connection and ban it if it was banned due to non accepted timeout.
+    fn should_discard(&mut self, time: Instant, connection: &Self::Connection) -> bool {
+        if connection
+            .non_accepted_timeout
+            .map_or(false, |timeout| timeout < time)
+        {
+            self.temporary_banned
+                .insert(connection.conn.remote_address, time + TEMPORARY_BAN_TIMEOUT);
+            return true;
+        }
+        connection.conn.should_drop(time)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ConnectionFactory, FactoryImpl, NON_ACCEPT_TIMEOUT, TEMPORARY_BAN_TIMEOUT};
+    use crate::packet::Packet;
+    use std::net::SocketAddr;
+    use std::time::{Duration, Instant};
+
+    /// The socket address of where the server is located.
+    const ADDR: &str = "127.0.0.1:10001";
+
+    fn address() -> SocketAddr {
+        ADDR.parse().unwrap()
+    }
+
+    fn user_event() -> Packet {
+        Packet::unreliable(address(), Default::default())
+    }
+
+    #[test]
+    fn accepting_local_connection_do_not_set_accept_timeout() {
+        let mut factory = FactoryImpl::new(Default::default());
+
+        let conn = factory
+            .should_accept_local(Instant::now(), address(), &user_event())
+            .unwrap();
+
+        assert_eq!(conn.non_accepted_timeout, None);
+    }
+
+    #[test]
+    fn accepting_remote_connection_sets_accept_timeout() {
+        let time = Instant::now();
+        let mut factory = FactoryImpl::new(Default::default());
+
+        let conn = factory.should_accept_remote(time, address(), &[]).unwrap();
+
+        assert_eq!(conn.non_accepted_timeout, Some(time + NON_ACCEPT_TIMEOUT));
+    }
+
+    #[test]
+    fn when_non_accept_timeout_expires_connection_is_discarded_and_banned() {
+        let time = Instant::now();
+        let mut factory = FactoryImpl::new(Default::default());
+
+        let conn = factory.should_accept_remote(time, address(), &[]).unwrap();
+        let time = time + NON_ACCEPT_TIMEOUT + Duration::from_nanos(1);
+        let is_discarded = factory.should_discard(time, &conn);
+        let banned = factory.temporary_banned.iter().nth(0).unwrap();
+
+        assert_eq!(is_discarded, true);
+        assert_eq!(*banned.0, address());
+        assert_eq!(*banned.1, time + TEMPORARY_BAN_TIMEOUT);
+    }
+
+    #[test]
+    fn accepting_remote_while_banned_returns_none() {
+        let time = Instant::now();
+        let mut factory = FactoryImpl::new(Default::default());
+
+        factory
+            .temporary_banned
+            .insert(address(), time + Duration::from_secs(100));
+        let conn = factory.should_accept_remote(time, address(), &[]);
+
+        assert_eq!(conn.is_none(), true);
+    }
+
+    #[test]
+    fn accepting_local_while_banned_removes_ban() {
+        let time = Instant::now();
+        let mut factory = FactoryImpl::new(Default::default());
+
+        factory
+            .temporary_banned
+            .insert(address(), time + Duration::from_secs(100));
+        let conn = factory.should_accept_local(time, address(), &user_event());
+
+        assert_eq!(conn.is_some(), true);
+        assert_eq!(factory.temporary_banned.is_empty(), true);
+    }
+}

--- a/src/net/socket_with_conditioner.rs
+++ b/src/net/socket_with_conditioner.rs
@@ -1,0 +1,62 @@
+use super::{DatagramSocket, LinkConditioner};
+use crate::error::Result;
+use std::net::{SocketAddr, UdpSocket};
+
+// Wrap `LinkConditioner` and `UdpSocket` together. LinkConditioner is enabled when building with a "tester" feature.
+#[derive(Debug)]
+pub struct SocketWithConditioner {
+    is_blocking_mode: bool,
+    socket: UdpSocket,
+    link_conditioner: Option<LinkConditioner>,
+}
+
+impl SocketWithConditioner {
+    pub fn new(socket: UdpSocket, is_blocking_mode: bool) -> Result<Self> {
+        socket.set_nonblocking(!is_blocking_mode)?;
+        Ok(SocketWithConditioner {
+            is_blocking_mode,
+            socket,
+            link_conditioner: None,
+        })
+    }
+
+    #[cfg(feature = "tester")]
+    pub fn set_link_conditioner(&mut self, link_conditioner: Option<LinkConditioner>) {
+        self.link_conditioner = link_conditioner;
+    }
+}
+
+/// Provides a `DatagramSocket` implementation for `SocketWithConditioner`.
+impl DatagramSocket for SocketWithConditioner {
+    // Determinates whether packet will be sent or not based on `LinkConditioner` if enabled.
+    fn send_packet(&mut self, addr: &SocketAddr, payload: &[u8]) -> std::io::Result<usize> {
+        if cfg!(feature = "tester") {
+            if let Some(ref mut link) = &mut self.link_conditioner {
+                if !link.should_send() {
+                    return Ok(0);
+                }
+            }
+        }
+        self.socket.send_to(payload, addr)
+    }
+
+    /// Receives a single packet from UDP socket.
+    fn receive_packet<'a>(
+        &mut self,
+        buffer: &'a mut [u8],
+    ) -> std::io::Result<(&'a [u8], SocketAddr)> {
+        self.socket
+            .recv_from(buffer)
+            .map(move |(recv_len, address)| (&buffer[..recv_len], address))
+    }
+
+    /// Returns the socket address that this socket was created from.
+    fn local_addr(&self) -> std::io::Result<SocketAddr> {
+        self.socket.local_addr()
+    }
+
+    /// Returns whether socket operates in blocking or non-blocking mode.
+    fn is_blocking_mode(&self) -> bool {
+        self.is_blocking_mode
+    }
+}

--- a/src/net/virtual_connection.rs
+++ b/src/net/virtual_connection.rs
@@ -404,6 +404,12 @@ impl VirtualConnection {
     pub fn gather_dropped_packets(&mut self) -> Vec<SentPacket> {
         self.acknowledge_handler.dropped_packets()
     }
+
+    /// Determines if the connection should be dropped due to its state.
+    pub fn should_drop(&self, time: Instant) -> bool {
+        self.packets_in_flight() > self.config.max_packets_in_flight
+            || self.last_heard(time) >= self.config.idle_connection_timeout
+    }
 }
 
 impl fmt::Debug for VirtualConnection {

--- a/src/packet/packet_structure.rs
+++ b/src/packet/packet_structure.rs
@@ -17,7 +17,7 @@ use crate::packet::{DeliveryGuarantee, OrderingGuarantee, PacketType};
 /// You are able to send packets with the above reliability types.
 pub struct Packet {
     /// The endpoint from where it came.
-    addr: SocketAddr,
+    pub(crate) addr: SocketAddr,
     /// The raw payload of the packet.
     payload: Box<[u8]>,
     /// Defines on how the packet will be delivered.

--- a/src/test_utils/fake_socket.rs
+++ b/src/test_utils/fake_socket.rs
@@ -2,20 +2,24 @@ use std::{net::SocketAddr, time::Instant};
 
 use crossbeam_channel::{Receiver, Sender};
 
-use crate::net::{ConnectionManager, LinkConditioner, VirtualConnection};
+use crate::net::{ConnectionManager, FactoryImpl, LinkConditioner};
 use crate::test_utils::*;
 use crate::{error::Result, Config, Packet, SocketEvent};
 
 /// Provides a similar to the real a `Socket`, but with emulated socket implementation.
 pub struct FakeSocket {
-    handler: ConnectionManager<EmulatedSocket, VirtualConnection>,
+    handler: ConnectionManager<EmulatedSocket, FactoryImpl>,
 }
 
 impl FakeSocket {
     /// Binds to the socket.
     pub fn bind(network: &NetworkEmulator, addr: SocketAddr, config: Config) -> Result<Self> {
         Ok(Self {
-            handler: ConnectionManager::new(network.new_socket(addr)?, config),
+            handler: ConnectionManager::new(
+                network.new_socket(addr)?,
+                FactoryImpl::new(config.clone()),
+                config,
+            ),
         })
     }
 


### PR DESCRIPTION
After some refactoring has been done, "connection manager" as was proposed here #246 became irrelevant, but instead, a much powerful abstraction became available.
This PR proposes a new trait `ConnectionFactory`, that basically allows a library user to provide its own, connection implementation.

Now all core traits, from bottom-up, looks like this:
* `Connection` - allows implementing an actual connection, also defines what user events it can receive, and what connection events it can send back to a user. This is a core component that actually is able to send packets and events to the user.
* `ConnectionFactory` - Defines a `Connection` type, decides when to accept or discard a connection, and provides conversion from user event to an actual connection address (`SocketAddr`). It cannot send any packets or events directly, but it can track and change the connection state.
* `ConnectionManager` - a core component that manages active connections and is generic on `DatagramSocket` and `ConnectionFactory`. Types for event channels (used to communicate with a user) depends on a ConnectionFactory type.
 Current `Socket` implementation only creates socket and connection factory instance and pass it to `ConnectionManager`, which provides all the needed functionality.

This PR is a minimum implementation (with some basic DDoS protection implemented in a factory), to start a discussion on how to organize code further so that it would provide convenient and flexible utilities for the user, to write more sophisticated connection implementations.

I suggest this course of action to prepare for multiple connection implementations:
1. create a new folder `src/connections/simple` and move `connection_impl.rs`, `events.rs`, `factory_impl.rs`, `socket.rs->simple.rs`, `virtual_connection.rs` to it.
2. rename `Socket` to `SimpleConnection` and add appropriate module definitions so that from the user perspective it could use it like this: `use laminar::connections::SimpleConnection;`
3. create `simple_connection` in `examples` and `tests` directories and move appropriate files in it.
4. extract useful bits and interfaces from `VirtualConnection` so other connections could use it as well. 
E.g. it would be nice to provide a process_incoming/outgoing functions, but with custom StandardHeader implementation.