### PR TITLE
Expose ConnectionManager and VirtualConnection

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,10 @@
 
 pub use self::config::Config;
 pub use self::error::{ErrorKind, Result};
-pub use self::net::{LinkConditioner, Socket, SocketEvent};
+pub use self::net::{
+    Connection, ConnectionManager, ConnectionMessenger, DatagramSocket, LinkConditioner, Socket,
+    SocketEvent, VirtualConnection,
+};
 pub use self::packet::{DeliveryGuarantee, OrderingGuarantee, Packet};
 #[cfg(feature = "tester")]
 pub use self::throughput::ThroughputMonitoring;


### PR DESCRIPTION
This change exposes `ConnectionManager` and `VirtualConnection` (and their dependencies) for public consumption.
It allows for integrating Laminar's connection handling and different Packet delivery guarantees with custom socket implementation.

For an example of running Laminar over [naia-socket](https://github.com/naia-rs/naia-socket) (webrtc-unreliable) see [soldank/server/networking.rs](https://github.com/smokku/soldank/blob/master/server/src/networking.rs#L26) / [soldank/client/networking.rs](https://github.com/smokku/soldank/blob/master/client/src/networking.rs#L42)