### PR TITLE
Add `Packet::into_payload`

### DIFF
--- a/src/packet/packet_structure.rs
+++ b/src/packet/packet_structure.rs
@@ -157,6 +157,11 @@ impl Packet {
         &self.payload
     }
 
+    /// Returns the payload of this packet.
+    pub fn into_payload(self) -> Box<[u8]> {
+        self.payload
+    }
+
     /// Returns the address of this packet.
     ///
     /// # Remark


### PR DESCRIPTION
This PR adds a single method to the `Packet` that returns the payload as a `Box<[u8]>` which may be useful to some.