### PR TITLE
Remove congestion control, since its results are never exposed or use…

### DIFF
--- a/src/infrastructure.rs
+++ b/src/infrastructure.rs
@@ -3,11 +3,9 @@
 
 pub use self::acknowledgment::AcknowledgmentHandler;
 pub use self::acknowledgment::SentPacket;
-pub use self::congestion::CongestionHandler;
 pub use self::fragmenter::Fragmentation;
 
 mod acknowledgment;
-mod congestion;
 mod fragmenter;
 
 pub mod arranging;

--- a/src/net.rs
+++ b/src/net.rs
@@ -5,7 +5,6 @@ pub use self::connection::{Connection, ConnectionEventAddress, ConnectionMesseng
 pub use self::connection_manager::{ConnectionManager, DatagramSocket};
 pub use self::events::SocketEvent;
 pub use self::link_conditioner::LinkConditioner;
-pub use self::quality::{NetworkQuality, RttMeasurer};
 pub use self::socket::Socket;
 pub use self::virtual_connection::VirtualConnection;
 
@@ -14,7 +13,6 @@ mod connection_impl;
 mod connection_manager;
 mod events;
 mod link_conditioner;
-mod quality;
 mod socket;
 mod virtual_connection;
 

--- a/src/sequence_buffer.rs
+++ b/src/sequence_buffer.rs
@@ -2,10 +2,8 @@ use std::clone::Clone;
 
 use crate::packet::SequenceNumber;
 
-pub use self::congestion_data::CongestionData;
 pub use self::reassembly_data::ReassemblyData;
 
-mod congestion_data;
 mod reassembly_data;
 
 /// Collection to store data of any kind.


### PR DESCRIPTION
This removes calls to the congestion control handler. Currently, the RTT is calculated and smoothed out over time.  With this, we can decide how to batch our packets and notify the user about network quality changes. Tho, those features are both not implemented but the implementation does do many underlying heap allocations in the 'SeqenceBuffer'. Therefore I think it is better to remove this for now. If someone wants to implement this property he is welcome to do so.